### PR TITLE
fix: multi-disc albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Sub-headings should group changes by type. Types are:
 Unreleased
 ----------
 
+[1.0.3] - 2025-04-20
+--------------------
+
+### Fixed
+
+* For albums with multiple discs, requesting disc 2 or more would incorrectly
+  return the data for disc 1. This affected CDDB and MSCD.
+
 [1.0.2] - 2025-03-20
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Unreleased
 
 * For albums with multiple discs, requesting disc 2 or more would incorrectly
   return the data for disc 1. This affected CDDB and MSCD.
+* CDDB over HTTP: Missing a trailing newline in the response broke some clients'
+  ability to process the response, like Exact Audio Copy.
 
 [1.0.2] - 2025-03-20
 --------------------

--- a/src/config/config.exs
+++ b/src/config/config.exs
@@ -14,6 +14,6 @@ config :cdigw, ecto_repos: [Cdigw.Repo]
 
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
-  metadata: [:peer]
+  metadata: [:peer, :request_id]
 
 import_config "#{Mix.env()}.exs"

--- a/src/config/config.exs
+++ b/src/config/config.exs
@@ -2,6 +2,7 @@ import Config
 
 config :cdigw, :http_server,
   hostname: "localhost",
+  public_ip: "127.0.0.1",
   port: 80
 
 config :cdigw, :cddbp_server,

--- a/src/config/releases.exs
+++ b/src/config/releases.exs
@@ -2,6 +2,7 @@ import Config
 
 config :cdigw, :http_server,
   hostname: System.get_env("HOSTNAME", "cddb.retrobridge.org"),
+  public_ip: System.get_env("PUBLIC_IP", "64.225.80.26"),
   port: System.get_env("HTTP_PORT", "80") |> String.to_integer()
 
 config :cdigw, :cddbp_server,

--- a/src/lib/cddb.ex
+++ b/src/lib/cddb.ex
@@ -78,13 +78,13 @@ defmodule Cddb do
       |> Map.put(:query, disc_info.query)
       |> Map.put_new(:interface, "cddb")
 
-    case MusicBrainz.find_release(disc_info.length_seconds, disc_info.track_lbas) do
-      {:ok, releases} ->
+    case MusicBrainz.find_discs(disc_info) do
+      {:ok, discs} ->
         # cddb effectively uses genre and disc ID as a composite key, so it
         # makes no sense to return disc with duplicated values.
         discs =
-          releases
-          |> Enum.map(&MusicBrainz.release_to_disc(disc_info.disc_id, &1))
+          discs
+          |> Enum.map(fn disc -> Map.put(disc, :id, disc_info.disc_id) end)
           |> Enum.uniq_by(fn disc -> {disc.genre, disc.id} end)
           |> maybe_cache_discs()
 

--- a/src/lib/cddb.ex
+++ b/src/lib/cddb.ex
@@ -1,4 +1,6 @@
 defmodule Cddb do
+  import Bitwise
+
   @moduledoc """
   High level interface and configuration for CDDB
   """
@@ -103,6 +105,53 @@ defmodule Cddb do
       nil -> {:error, :not_found}
       disc -> {:ok, disc}
     end
+  end
+
+  @doc """
+  Calculate the CDDB Disc ID given the disc structure
+
+  https://courses.cs.duke.edu/cps006g/fall04/class/isis/freedb.pdf
+
+      iex> Cddb.calculate_disc_id(%{length_seconds: 4519, track_lbas: [150, 18064, 34719, 48510, 64506, 82409, 99569, 117860, 137646, 147539, 166275, 184290, 205587, 223455, 241522, 258378, 275550, 294931, 320173]})
+      "1f11a513"
+
+      iex> Cddb.calculate_disc_id(%{lead_out_lba: 338952, track_lbas: [150, 18064, 34719, 48510, 64506, 82409, 99569, 117860, 137646, 147539, 166275, 184290, 205587, 223455, 241522, 258378, 275550, 294931, 320173]})
+      "1f11a513"
+  """
+  def calculate_disc_id(%{track_lbas: toc, lead_out_lba: lead_out_lba}) do
+    calculate_disc_id(%{track_lbas: toc, length_seconds: floor(lead_out_lba / 75)})
+  end
+
+  def calculate_disc_id(%{track_lbas: track_lbas, length_seconds: length_seconds}) do
+    # On a music CD, each second is stored across 75 frames or sectors of the disc.
+    # Each LBA offset indicates how many frames/sectors into the disc the track starts.
+    frames_per_second = 75
+
+    # Tracks are not necessarily stored in evenly divisible numbers of frames.
+    # CDDB doesn't include partial frame numbers for this calculation.
+    second_offsets = Enum.map(track_lbas, fn lba -> floor(lba / frames_per_second) end)
+
+    # Each second offset's digits are tallied e.g. "152" => 1 + 5 + 2 = 8
+    n =
+      Enum.reduce(second_offsets, 0, fn sec, acc ->
+        sec
+        |> Integer.digits()
+        |> Enum.sum()
+        |> Kernel.+(acc)
+      end)
+      |> Kernel.rem(0xFF)
+
+    # CDDB queries don't explicitly send where the leadout starts but we
+    # can take an educated guess based on the total length and the first track offset.
+    leadout_sec = length_seconds - Enum.at(second_offsets, 0)
+    track_count = Enum.count(track_lbas)
+
+    tot = n <<< 24 ||| leadout_sec <<< 8 ||| track_count
+
+    tot
+    |> Integer.to_string(16)
+    |> String.pad_leading(8, "0")
+    |> String.downcase()
   end
 
   defp maybe_cache_discs([]), do: []

--- a/src/lib/cdigw_web/cddb_plug.ex
+++ b/src/lib/cdigw_web/cddb_plug.ex
@@ -6,6 +6,8 @@ defmodule CdigwWeb.CddbPlug do
   import Plug.Conn
   require Logger
 
+  @newline "\n"
+
   def init(options), do: options
 
   def call(conn, _opts) do
@@ -62,10 +64,20 @@ defmodule CdigwWeb.CddbPlug do
   defp send_encoded_response(conn, response, proto) do
     {charset, encoded} = Cddb.encode_response(response, proto)
 
+    encoded = ensure_trailing_newline(encoded)
+
     Logger.debug("response enc=#{charset} body=<<<EOF\n#{encoded}\nEOF")
 
     conn
     |> put_resp_content_type("text/plain", charset)
     |> send_resp(200, encoded)
+  end
+
+  def ensure_trailing_newline(str) do
+    if String.last(str) == @newline do
+      str
+    else
+      str <> @newline
+    end
   end
 end

--- a/src/lib/cdigw_web/endpoint.ex
+++ b/src/lib/cdigw_web/endpoint.ex
@@ -24,6 +24,7 @@ defmodule CdigwWeb.Endpoint do
 
     conn
     |> assign(:recent_lookups, recent_lookups)
+    |> assign(:public_ip, Cdigw.http_config()[:public_ip])
     |> render("index")
   end
 

--- a/src/lib/cdigw_web/mscd_plug.ex
+++ b/src/lib/cdigw_web/mscd_plug.ex
@@ -10,6 +10,7 @@ defmodule CdigwWeb.MscdPlug do
   # Sending UTF-8 garbles non-ASCII chars. Setting the `charset` has no effect,
   # but send it anyway to correctly indicate how we've encoded the text.
   @content_type "text/plain; charset=iso-8859-1"
+  @newline "\n"
 
   def init(options), do: options
 
@@ -29,12 +30,20 @@ defmodule CdigwWeb.MscdPlug do
 
         conn
         |> put_resp_header("content-type", @content_type)
-        |> send_resp(200, response)
+        |> send_resp(200, ensure_trailing_newline(response))
 
       {:error, :not_found} ->
         conn
         |> put_resp_header("content-type", @content_type)
         |> send_resp(404, "No matching disc found")
+    end
+  end
+
+  defp ensure_trailing_newline(str) do
+    if String.last(str) == @newline do
+      str
+    else
+      str <> @newline
     end
   end
 end

--- a/src/lib/cdigw_web/templates/index.html.eex
+++ b/src/lib/cdigw_web/templates/index.html.eex
@@ -227,9 +227,7 @@
       </p>
       <p>
         Add this entry, save, and it should start working right away.
-<pre>
-188.166.117.156 www.tunes.com
-</pre>
+        <pre><%= @public_ip %> www.tunes.com</pre>
       </p>
 
       <p>
@@ -246,9 +244,7 @@
 
       <h4>Windows 98</h4>
       <p>Edit <code>C:\Windows\Hosts</code> and add the following line:</p>
-<pre>
-188.166.117.156 cddb.cddb.com
-</pre>
+      <pre><%= @public_ip %> cddb.cddb.com</pre>
 
       <h3>cdrdao v1.2.4</h3>
       <p class="success">Working!</p>

--- a/src/lib/mscd/response.ex
+++ b/src/lib/mscd/response.ex
@@ -14,9 +14,7 @@ defmodule Mscd.Response do
       |> render_fields()
       |> Enum.map(fn {key, value} -> "#{key}=#{value}" end)
 
-    body = ["[CD]" | body]
-
-    Enum.join(body, @line_separator)
+    Enum.join(["[CD]" | body], @line_separator)
   end
 
   def render_fields(%Disc{title: title, artist: artist, tracks: tracks}) do

--- a/src/lib/music_brainz.ex
+++ b/src/lib/music_brainz.ex
@@ -2,7 +2,6 @@ defmodule MusicBrainz do
   @moduledoc """
   Client library for accessing the MusicBrainz API over HTTP
   """
-
   use Tesla
   import Ext.Enum, only: [dig: 2]
   alias Cddb.Disc
@@ -64,14 +63,16 @@ defmodule MusicBrainz do
   end
 
   @doc """
-  Find a disc by its length in seconds and track LBA TOC
+  Find a disc by its track LBA TOC and either length in seconds or lead-out LBA.
 
   When coming from a CDDB query, we know:
 
     * the length of the CD in seconds
     * the sector where each audio track begins (TOC)
 
-  To query for a CD by TOC, we also need to know the sector where the lead-out
+  When coming from an MSCD query, we know the TOC and lead-out LBA.
+
+  To query for a CD by TOC, we need to know the sector where the lead-out
   track begins. We can guess this by multiplying the sectors per second (75)
   by the seconds of audio on the disc.
 
@@ -80,18 +81,21 @@ defmodule MusicBrainz do
   Since we know what the audio track TOC is though, we can match on it exactly
   to find our disc amongst the multiple results.
   """
-  def find_release(length_seconds, toc) when is_integer(length_seconds) and is_list(toc) do
-    toc = ensure_int_list(toc)
-    guessed_leadout_lba = length_seconds * @sectors_per_second
+  def find_releases(%{track_lbas: toc, length_seconds: secs}) do
+    find_releases(%{track_lbas: toc, lead_out_lba: secs * @sectors_per_second})
+  end
+
+  def find_releases(%{track_lbas: track_lbas, lead_out_lba: lead_out_lba}) do
+    toc = ensure_int_list(track_lbas)
     track_count = length(toc)
-    toc_query = [1, track_count, guessed_leadout_lba] ++ toc
+    toc_query = [1, track_count, lead_out_lba] ++ toc
 
     case fuzzy_search_by_toc(toc_query) do
       {:ok, %{status: 200, body: body}} ->
         matches =
           body
           |> Map.get("releases")
-          |> Enum.filter(fn rel -> toc_matches?(rel, toc) end)
+          |> Enum.filter(fn rel -> any_toc_matches?(rel, toc) end)
 
         {:ok, matches}
 
@@ -100,6 +104,75 @@ defmodule MusicBrainz do
     end
   end
 
+  @doc """
+  Both CDDB and MSCD think in terms of a disc and not a release/album.
+  For multi-disc releases, we have to combine data from the release with the
+  track listing.
+  """
+  def find_discs(%{track_lbas: toc} = disc_info) do
+    case find_releases(disc_info) do
+      {:ok, releases} ->
+        # Select the disc that matches the TOC.
+        # We may also be able to select by calculated MB disc ID, at least for MSCD
+        discs = releases_to_discs(releases, fn m -> toc_matches?(m, toc) end)
+
+        {:ok, discs}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      other ->
+        {:error, other}
+    end
+  end
+
+  defp releases_to_discs(releases, matcher) when is_function(matcher) do
+    Enum.map(releases, fn release ->
+      year = year_from_date(release["date"])
+
+      disc = %Disc{
+        artist: groom_text(dig(release, ["artist-credit", 0, "name"])),
+        title: groom_text(release["title"]),
+        year: year,
+        genre: genre(release["genres"])
+      }
+
+      # Get track data from the "media" element that has a matching TOC
+      wanted_disc = Enum.find(release["media"], matcher)
+
+      Enum.reduce(wanted_disc["tracks"], disc, fn track, disc ->
+        title = groom_text(dig(track, ["recording", "title"]))
+        Disc.add_track(disc, title)
+      end)
+    end)
+  end
+
+  defp year_from_date(nil), do: nil
+
+  defp year_from_date(str) do
+    case Regex.named_captures(~r/^(?<year>\d{4})-/, str) do
+      %{"year" => str} ->
+        str
+
+      _ ->
+        nil
+    end
+  end
+
+  # A release is an album that may have multiple discs. To see if this release
+  # is a match to the given CD, see if any of the discs have a matching TOC.
+  defp any_toc_matches?(release, toc) do
+    Enum.any?(release["media"], fn media -> toc_matches?(media, toc) end)
+  end
+
+  # A disc has one or more media elements. Find the one with the matching TOC
+  defp toc_matches?(medium, toc) do
+    Enum.any?(medium["discs"], fn disc -> disc["offsets"] == toc end)
+  end
+
+  @doc """
+  Fetch releases matching the disc ID derived from track data.
+  """
   def get_releases_by_disc_id(id, inc \\ @default_inc) do
     inc_list = Enum.join(inc, "+")
 
@@ -110,35 +183,6 @@ defmodule MusicBrainz do
       other ->
         {:error, other}
     end
-  end
-
-  @doc """
-  Convert a release to a `Disc` structure
-  """
-  def release_to_disc(cddb_disc_id, release) do
-    year =
-      case Regex.named_captures(~r/^(?<year>\d{4})-/, release["date"] || "") do
-        %{"year" => str} ->
-          str
-
-        _ ->
-          nil
-      end
-
-    disc = %Disc{
-      id: cddb_disc_id,
-      artist: groom_text(dig(release, ["artist-credit", 0, "name"])),
-      title: groom_text(release["title"]),
-      year: year,
-      genre: genre(release["genres"])
-    }
-
-    release
-    |> dig(["media", 0, "tracks"])
-    |> Enum.reduce(disc, fn track, disc ->
-      title = groom_text(dig(track, ["recording", "title"]))
-      Disc.add_track(disc, title)
-    end)
   end
 
   @doc """
@@ -179,11 +223,6 @@ defmodule MusicBrainz do
     genres
     |> Enum.map(fn %{"name" => name} -> name |> String.split() |> hd() end)
     |> Enum.find(@default_genre, fn name -> Enum.member?(Cddb.genres(), name) end)
-  end
-
-  defp toc_matches?(release, toc) do
-    discs = dig(release, ["media", 0, "discs"]) || []
-    Enum.any?(discs, fn disc -> disc["offsets"] == toc end)
   end
 
   defp ensure_int_list(items) do

--- a/src/test/cdigw_web/query_test.exs
+++ b/src/test/cdigw_web/query_test.exs
@@ -124,7 +124,7 @@ defmodule CdigwWeb.CddbPlugTest do
     query_req = conn(:get, "?cmd=#{cmd}&proto=#{proto}")
     query_resp = CddbPlug.call(query_req, %{})
 
-    assert query_resp.resp_body == "202 No match"
+    assert query_resp.resp_body == "202 No match\n"
   end
 
   @tag capture_log: true

--- a/src/test/cdigw_web/query_test.exs
+++ b/src/test/cdigw_web/query_test.exs
@@ -2,13 +2,7 @@ defmodule CdigwWeb.CddbPlugTest do
   use ExUnit.Case
   use Plug.Test
 
-  alias CdigwWeb.CddbPlug
-
-  defp mock_response(:fuzzy) do
-    "test/fixtures/music_brainz/fuzzy_response.json"
-    |> File.read!()
-    |> Jason.decode!()
-  end
+  alias CdigwWeb.{CddbPlug, MscdPlug}
 
   defp mock_response(:no_matches) do
     %{
@@ -18,6 +12,12 @@ defmodule CdigwWeb.CddbPlugTest do
     }
   end
 
+  defp mock_response(name) do
+    "test/fixtures/music_brainz/#{name}.json"
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
   setup do
     Tesla.Mock.mock(fn
       %{
@@ -25,7 +25,21 @@ defmodule CdigwWeb.CddbPlugTest do
         url:
           "https://musicbrainz.org/ws/2/discid/-?fmt=json&inc=artists+recordings+genres&toc=1+13+205050+150+15239+29625+45763+61420+75862+91642+108918+123698+139895+153589+169239+188495"
       } ->
-        Tesla.Mock.json(mock_response(:fuzzy))
+        Tesla.Mock.json(mock_response(:fuzzy_response))
+
+      %{
+        method: :get,
+        url:
+          "https://musicbrainz.org/ws/2/discid/-?fmt=json&inc=artists+recordings+genres&toc=1+19+338925+150+18064+34719+48510+64506+82409+99569+117860+137646+147539+166275+184290+205587+223455+241522+258378+275550+294931+320173"
+      } ->
+        Tesla.Mock.json(mock_response(:release_with_multiple_discs))
+
+      %{
+        method: :get,
+        url:
+          "https://musicbrainz.org/ws/2/discid/-?fmt=json&inc=artists+recordings+genres&toc=1+19+338952+150+18064+34719+48510+64506+82409+99569+117860+137646+147539+166275+184290+205587+223455+241522+258378+275550+294931+320173"
+      } ->
+        Tesla.Mock.json(mock_response(:release_with_multiple_discs))
 
       %{
         method: :get,
@@ -39,7 +53,7 @@ defmodule CdigwWeb.CddbPlugTest do
   end
 
   @tag capture_log: true
-  test "query and read cycle" do
+  test "CDDB: query and read cycle" do
     proto = 5
 
     cmd =
@@ -101,7 +115,7 @@ defmodule CdigwWeb.CddbPlugTest do
   end
 
   @tag capture_log: false
-  test "query with no hits on MusicBrainz" do
+  test "CDDB: query with no hits on MusicBrainz" do
     proto = "6"
 
     cmd =
@@ -111,5 +125,117 @@ defmodule CdigwWeb.CddbPlugTest do
     query_resp = CddbPlug.call(query_req, %{})
 
     assert query_resp.resp_body == "202 No match"
+  end
+
+  @tag capture_log: true
+  test "CDDB: query for CD2 in a multi-disc release" do
+    proto = 6
+
+    cmd =
+      "cddb+query+1F11A513+19+150+18064+34719+48510+64506+82409+99569+117860+137646+147539+166275+184290+205587+223455+241522+258378+275550+294931+320173+4519&hello=ExactAudioCopy+freedb+v0.99"
+
+    query_req = conn(:get, "?cmd=#{cmd}&proto=#{proto}")
+    query_resp = CddbPlug.call(query_req, %{})
+
+    expected = ~S"""
+    200 misc 1F11A513 Taylor Swift / THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY
+    """
+
+    assert query_resp.resp_body == expected
+
+    read_req = conn(:get, "?cmd=cddb+read+misc+1F11A513&proto=#{proto}")
+    read_resp = CddbPlug.call(read_req, %{})
+
+    # Notice TTITLE4 having an asterisk instead of an apostrophe
+    # The actual disc data has the apostrophe encoded as an angled one which
+    # is not supported by ISO-8859-1 so gets replaced with a question mark
+    expected_read = ~S"""
+    210 misc 1F11A513 CD database entry follows (until terminating `.')
+    DISCID=1F11A513
+    DTITLE=Taylor Swift / THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY
+    DYEAR=2024
+    DGENRE=misc
+    TTITLE0=The Black Dog
+    TTITLE1=imgonnagetyouback
+    TTITLE2=The Albatross
+    TTITLE3=Chloe or Sam or Sophia or Marcus
+    TTITLE4=How Did It End?
+    TTITLE5=So High School
+    TTITLE6=I Hate It Here
+    TTITLE7=thanK you aIMee
+    TTITLE8=I Look in People's Windows
+    TTITLE9=The Prophecy
+    TTITLE10=Cassandra
+    TTITLE11=Peter
+    TTITLE12=The Bolter
+    TTITLE13=Robin
+    TTITLE14=The Manuscript
+    TTITLE15=Fortnight (acoustic version)
+    TTITLE16=Down Bad (acoustic version)
+    TTITLE17=But Daddy I Love Him (acoustic version)
+    TTITLE18=Guilty as Sin? (acoustic version)
+    EXTD=
+    EXTT0=
+    EXTT1=
+    EXTT2=
+    EXTT3=
+    EXTT4=
+    EXTT5=
+    EXTT6=
+    EXTT7=
+    EXTT8=
+    EXTT9=
+    EXTT10=
+    EXTT11=
+    EXTT12=
+    EXTT13=
+    EXTT14=
+    EXTT15=
+    EXTT16=
+    EXTT17=
+    EXTT18=
+    PLAYORDER=
+    .
+    """
+
+    assert read_resp.resp_body == expected_read
+  end
+
+  @tag capture_log: true
+  test "MSCD: query CD2 of a two-disc release" do
+    cd =
+      "13+96+4690+879F+BD7E+FBFA+141E9+184F1+1CC64+219AE+24053+28983+2CFE2+32313+368DF+3AF72+3F14A+4345E+48013+4E2AD+52C08"
+
+    req = conn(:get, "/tunes-cgi2/tunes/disc_info/203/cd=#{cd}")
+    resp = MscdPlug.call(req, %{cd: cd})
+
+    expected = ~S"""
+    [CD]
+    CERTIFICATE=41d602112509916cb8f45f81164805e29bfef1946c88dc57
+    Mode=0
+    Title=THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY
+    Artist=Taylor Swift
+    Track1=The Black Dog
+    Track2=imgonnagetyouback
+    Track3=The Albatross
+    Track4=Chloe or Sam or Sophia or Marcus
+    Track5=How Did It End?
+    Track6=So High School
+    Track7=I Hate It Here
+    Track8=thanK you aIMee
+    Track9=I Look in People's Windows
+    Track10=The Prophecy
+    Track11=Cassandra
+    Track12=Peter
+    Track13=The Bolter
+    Track14=Robin
+    Track15=The Manuscript
+    Track16=Fortnight (acoustic version)
+    Track17=Down Bad (acoustic version)
+    Track18=But Daddy I Love Him (acoustic version)
+    Track19=Guilty as Sin? (acoustic version)
+    """
+
+    assert resp.resp_body == String.strip(expected)
   end
 end

--- a/src/test/cdigw_web/query_test.exs
+++ b/src/test/cdigw_web/query_test.exs
@@ -236,6 +236,6 @@ defmodule CdigwWeb.CddbPlugTest do
     Track19=Guilty as Sin? (acoustic version)
     """
 
-    assert resp.resp_body == String.strip(expected)
+    assert resp.resp_body == expected
   end
 end

--- a/src/test/fixtures/music_brainz/release_with_multiple_discs.json
+++ b/src/test/fixtures/music_brainz/release_with_multiple_discs.json
@@ -1,0 +1,12045 @@
+{
+  "release-count": 4,
+  "release-offset": 0,
+  "releases": [
+    {
+      "cover-art-archive": {
+        "back": true,
+        "artwork": true,
+        "front": true,
+        "darkened": false,
+        "count": 9
+      },
+      "genres": [],
+      "text-representation": {
+        "language": "eng",
+        "script": "Latn"
+      },
+      "artist-credit": [
+        {
+          "name": "Taylor Swift",
+          "artist": {
+            "name": "Taylor Swift",
+            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+            "id": "20244d07-534f-4eff-b4d4-930878889970",
+            "country": "US",
+            "disambiguation": "",
+            "sort-name": "Swift, Taylor",
+            "type": "Person",
+            "genres": [
+              {
+                "count": 1,
+                "name": "alternative pop",
+                "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                "disambiguation": ""
+              },
+              {
+                "name": "contemporary country",
+                "count": 5,
+                "disambiguation": "",
+                "id": "31c0b6ff-a356-4c73-91d7-203c80e6646b"
+              },
+              {
+                "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                "disambiguation": "",
+                "name": "country",
+                "count": 21
+              },
+              {
+                "name": "country pop",
+                "count": 20,
+                "disambiguation": "",
+                "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+              },
+              {
+                "disambiguation": "",
+                "id": "3f3388b4-e36a-4bf8-a0be-66b10d92aaa4",
+                "count": 1,
+                "name": "electropop"
+              },
+              {
+                "disambiguation": "",
+                "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                "name": "indie folk",
+                "count": 2
+              },
+              {
+                "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                "disambiguation": "",
+                "count": 35,
+                "name": "pop"
+              },
+              {
+                "count": 6,
+                "name": "pop rock",
+                "disambiguation": "",
+                "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+              },
+              {
+                "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                "disambiguation": "",
+                "count": 5,
+                "name": "singer-songwriter"
+              },
+              {
+                "disambiguation": "",
+                "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                "count": 4,
+                "name": "synth-pop"
+              }
+            ]
+          },
+          "joinphrase": ""
+        }
+      ],
+      "barcode": "4988031752302",
+      "status": "Official",
+      "release-events": [
+        {
+          "area": {
+            "name": "Japan",
+            "type-id": null,
+            "iso-3166-1-codes": [
+              "JP"
+            ],
+            "sort-name": "Japan",
+            "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+            "disambiguation": "",
+            "type": null
+          },
+          "date": "2024-12-27"
+        }
+      ],
+      "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+      "title": "THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY",
+      "country": "JP",
+      "date": "2024-12-27",
+      "packaging": "Gatefold Cover",
+      "asin": null,
+      "disambiguation": "",
+      "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+      "quality": "normal",
+      "media": [
+        {
+          "discs": [],
+          "position": 1,
+          "track-count": 16,
+          "format": "CD",
+          "title": "",
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "track-offset": 0,
+          "tracks": [
+            {
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "name": "Post Malone",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "genres": [
+                      {
+                        "name": "contemporary r&b",
+                        "count": 1,
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 1,
+                        "name": "country",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 5,
+                        "name": "hip hop",
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "disambiguation": ""
+                      },
+                      {
+                        "name": "pop rap",
+                        "count": 2,
+                        "disambiguation": "",
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237"
+                      },
+                      {
+                        "count": 2,
+                        "name": "trap",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": ""
+                      }
+                    ],
+                    "disambiguation": "",
+                    "sort-name": "Post Malone",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Post Malone",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "recording": {
+                "id": "a06d6b37-9cae-40a5-806d-1a3c4f8098c0",
+                "title": "Fortnight",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "cloud rap",
+                    "id": "2346fb3e-8546-4119-a929-601db8e0a733",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                    "name": "contemporary r&b",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "country rap",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "9eb1c5f6-fa0a-495b-beb6-aba292fd3bbe"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rap",
+                    "disambiguation": "",
+                    "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "b4b184b7-6224-478e-a273-f9da9ee30136",
+                    "name": "rap rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": " featuring "
+                  },
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "sort-name": "Post Malone"
+                    },
+                    "name": "Post Malone",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 228965
+              },
+              "position": 1,
+              "title": "Fortnight",
+              "number": "1",
+              "id": "0780f44c-3a2b-466a-9993-3c463577012c"
+            },
+            {
+              "length": 293000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor"
+                  }
+                }
+              ],
+              "id": "80fa37ec-be43-401b-a156-52a1728a6748",
+              "number": "2",
+              "title": "The Tortured Poets Department",
+              "recording": {
+                "title": "The Tortured Poets Department",
+                "id": "74fb3457-7db6-486d-be0b-af896a3925d9",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 293053,
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 3,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 5
+                  }
+                ]
+              },
+              "position": 2
+            },
+            {
+              "title": "My Boy Only Breaks His Favorite Toys",
+              "recording": {
+                "title": "My Boy Only Breaks His Favorite Toys",
+                "id": "b1c44139-75ff-43a2-8dc6-c332ee8e16a4",
+                "length": 203800,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 4,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": ""
+              },
+              "position": 3,
+              "id": "56975c41-7563-4ffc-94e7-ce074b994dcd",
+              "number": "3",
+              "length": 204000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "id": "db29f949-b361-494f-b10b-1f9a02183d65",
+              "number": "4",
+              "title": "Down Bad",
+              "position": 4,
+              "recording": {
+                "id": "3bdc0830-9f84-4e10-82e7-a6fd6d0d4ebc",
+                "title": "Down Bad",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 2,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 3,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "length": 261226,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "length": 261000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "id": "e3804f06-9235-4b59-80df-9af5bc2bf6f2",
+              "number": "5",
+              "title": "So Long, London",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": ""
+                    }
+                  }
+                ],
+                "length": 262973,
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "So Long, London",
+                "id": "01e1cfa1-ee04-4e35-bca7-03c017ad86e3"
+              },
+              "position": 5,
+              "length": 263000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "length": 340000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "number": "6",
+              "id": "614f5684-5647-4ee7-87eb-72dcd796554c",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "length": 340426,
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 3,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "But Daddy I Love Him",
+                "id": "4399ef75-afc5-4e22-94ff-2a2d126e4e8e"
+              },
+              "position": 6,
+              "title": "But Daddy I Love Him"
+            },
+            {
+              "id": "60d0af3e-dc57-4aab-b7d3-5582802fc8b7",
+              "number": "7",
+              "title": "Fresh Out the Slammer",
+              "position": 7,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 210786,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "title": "Fresh Out the Slammer",
+                "id": "200a1d4b-2f3a-462b-8f98-20f1fc778928"
+              },
+              "length": 211000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "length": 215000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "artist": {
+                    "country": "GB",
+                    "disambiguation": "",
+                    "sort-name": "Florence and the Machine",
+                    "genres": [
+                      {
+                        "disambiguation": "",
+                        "id": "ceeaa283-5d7b-4202-8d1d-e25d116b2a18",
+                        "name": "alternative rock",
+                        "count": 2
+                      },
+                      {
+                        "count": 3,
+                        "name": "art pop",
+                        "id": "930ef127-3653-4677-9b95-ecc90c7c1a14",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 5,
+                        "name": "indie pop",
+                        "id": "f390be72-360b-41bb-a310-6a2e638779d2",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 7,
+                        "name": "indie rock",
+                        "id": "ccd19ebf-052c-4afe-8ad9-fbb0a73f94a7",
+                        "disambiguation": ""
+                      },
+                      {
+                        "name": "pop",
+                        "count": 2,
+                        "disambiguation": "",
+                        "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                        "count": 1,
+                        "name": "pop rock"
+                      }
+                    ],
+                    "type": "Group",
+                    "name": "Florence + the Machine",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6"
+                  },
+                  "name": "Florence + the Machine",
+                  "joinphrase": ""
+                }
+              ],
+              "number": "8",
+              "id": "adbc6117-aa65-43c6-bd2c-0daaddb76f40",
+              "recording": {
+                "title": "Florida!!!",
+                "id": "8e857bc8-4214-42b5-878a-c00567a9a3d1",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": " feat. "
+                  },
+                  {
+                    "name": "Florence + the Machine",
+                    "artist": {
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "name": "Florence + the Machine",
+                      "country": "GB",
+                      "type": "Group",
+                      "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6",
+                      "sort-name": "Florence and the Machine",
+                      "disambiguation": ""
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 215466,
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 3,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 8,
+              "title": "Florida!!!"
+            },
+            {
+              "position": 9,
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 3
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 3,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "length": 254360,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "id": "b9262b85-ff4a-44db-aa6d-8dc8357c086d",
+                "title": "Guilty as Sin?"
+              },
+              "title": "Guilty as Sin?",
+              "number": "9",
+              "id": "ab141989-3e52-416c-9516-98c09188a7e6",
+              "length": 254000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 334000,
+              "recording": {
+                "title": "Who’s Afraid of Little Old Me?",
+                "id": "d9630f72-27df-4369-973d-537cf2eb2954",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 334085,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 10,
+              "title": "Who’s Afraid of Little Old Me?",
+              "number": "10",
+              "id": "4f5bb940-d911-47ac-b839-9303631693f6"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 156000,
+              "title": "I Can Fix Him (No Really I Can)",
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 156293,
+                "id": "085dab8e-2569-4864-8db5-fe150fd2587e",
+                "title": "I Can Fix Him (No Really I Can)"
+              },
+              "position": 11,
+              "id": "d366d714-9e72-4392-aa73-61ec77416c5f",
+              "number": "11"
+            },
+            {
+              "length": 277000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "number": "12",
+              "id": "006b85d4-b0c2-436a-87cd-0f26374a84eb",
+              "recording": {
+                "title": "loml",
+                "id": "ca5ab5ea-e0e7-4b2f-9124-a616b9fa0495",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    }
+                  }
+                ],
+                "length": 277160,
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 12,
+              "title": "loml"
+            },
+            {
+              "recording": {
+                "id": "940a2ac0-be80-4b48-a6cc-d1ac04a7d448",
+                "title": "I Can Do It With a Broken Heart",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "id": "b739a895-85ed-4ad3-8717-4e9ef5387dd8",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "dance-pop"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 4,
+                    "name": "synth-pop"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "length": 218000,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "position": 13,
+              "title": "I Can Do It With a Broken Heart",
+              "number": "13",
+              "id": "5de4ccd3-e4b0-446f-b6ac-95a4b48d290c",
+              "length": 218000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "number": "14",
+              "id": "240f91f2-2092-4225-bff6-d683927592de",
+              "recording": {
+                "title": "The Smallest Man Who Ever Lived",
+                "id": "ff7194ba-c5d3-4ce4-b231-bd90f7e9d187",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 245546,
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "34cd43be-4711-4e77-a25c-c6d6a4bf3cb4",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "piano rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ]
+              },
+              "position": 14,
+              "title": "The Smallest Man Who Ever Lived",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 246000
+            },
+            {
+              "id": "b62c6c44-fd7c-4a26-9ec5-f7e3cb4ce5a4",
+              "number": "15",
+              "title": "The Alchemy",
+              "position": 15,
+              "recording": {
+                "id": "69a95746-70cc-44b0-a72b-1e6ac59f16a1",
+                "title": "The Alchemy",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "length": 196893,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ]
+              },
+              "length": 197000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  }
+                }
+              ],
+              "length": 217000,
+              "number": "16",
+              "id": "56e76310-fcb0-48ac-ae40-a3d327bf1cf4",
+              "recording": {
+                "length": 216666,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "name": "folk pop",
+                    "count": 1,
+                    "id": "abb2374f-30e5-4d3e-b417-2caf78ef1f6c",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "title": "Clara Bow",
+                "id": "1856e61e-2dde-4b5b-b596-5cb69fe0e211"
+              },
+              "position": 16,
+              "title": "Clara Bow"
+            }
+          ]
+        },
+        {
+          "track-count": 19,
+          "format": "CD",
+          "discs": [],
+          "position": 2,
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "title": "",
+          "tracks": [
+            {
+              "length": 239000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "position": 1,
+              "recording": {
+                "id": "a47f30f9-53f4-4222-8b38-934f818b41d1",
+                "title": "The Black Dog",
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "f0843e91-c025-4dd7-8aef-6fe3d35470d9",
+                    "count": 1,
+                    "name": "chamber pop"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 239000
+              },
+              "title": "The Black Dog",
+              "number": "1",
+              "id": "f53d1293-1e1c-4bad-bd05-4565df1e0694"
+            },
+            {
+              "recording": {
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 222072,
+                "id": "0ac1a42e-298d-41d6-b08f-817f27c730a3",
+                "title": "imgonnagetyouback"
+              },
+              "position": 2,
+              "title": "imgonnagetyouback",
+              "number": "2",
+              "id": "6fb7f6b1-7779-4f54-9cd4-713ed7fc448f",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 222000
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 184000,
+              "title": "The Albatross",
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "length": 183893,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "6403174f-77a7-4c9d-91ca-4cbfcd097b00",
+                "title": "The Albatross"
+              },
+              "position": 3,
+              "id": "122c688c-b2a7-4eba-9d7d-7612609c59a8",
+              "number": "3"
+            },
+            {
+              "length": 213000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "recording": {
+                "id": "5a15e447-8d79-4be7-899b-f10d5a60765f",
+                "title": "Chloe or Sam or Sophia or Marcus",
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 213281
+              },
+              "position": 4,
+              "title": "Chloe or Sam or Sophia or Marcus",
+              "number": "4",
+              "id": "45e27e10-8c0b-4aba-b064-2e100f791aae"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 239000,
+              "title": "How Did It End?",
+              "recording": {
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 238707,
+                "id": "e61dd61f-718f-46c1-86a7-29959bb08a3d",
+                "title": "How Did It End?"
+              },
+              "position": 5,
+              "id": "ab6e7f14-8255-42e8-bd51-ec85956b7570",
+              "number": "5"
+            },
+            {
+              "title": "So High School",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 228800,
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "title": "So High School",
+                "id": "86c2568a-bb6f-4f9a-b491-d2ab09757849"
+              },
+              "position": 6,
+              "id": "24a155f1-3044-49ca-8076-fff68e68a9dc",
+              "number": "6",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 244000,
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "length": 243876,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "id": "75e3a05a-6a05-45d7-b360-7dc3053cf873",
+                "title": "I Hate It Here"
+              },
+              "position": 7,
+              "title": "I Hate It Here",
+              "number": "7",
+              "id": "0f6df366-6df2-48a2-990b-d37ca482c55d"
+            },
+            {
+              "position": 8,
+              "recording": {
+                "title": "thanK you aIMee",
+                "id": "97c08c98-c016-47ed-9a85-601c00366edf",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 264000,
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ]
+              },
+              "title": "thanK you aIMee",
+              "number": "8",
+              "id": "e36653d7-cf5e-450b-a588-56e0eecdd0a4",
+              "length": 264000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "id": "de176358-48f2-4cc3-a5cc-53f82f9c1b63",
+              "number": "9",
+              "title": "I Look in People’s Windows",
+              "recording": {
+                "id": "8ab53640-10f4-4d01-9f92-75c7daa5ee25",
+                "title": "I Look in People’s Windows",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "length": 131907,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ]
+              },
+              "position": 9,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 132000
+            },
+            {
+              "length": 250000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "1a534d61-e29f-4bba-a998-f3982266ed2c",
+              "number": "10",
+              "title": "The Prophecy",
+              "position": 10,
+              "recording": {
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 249807,
+                "id": "e6f177d7-d979-4260-9ed2-66638c02ec3b",
+                "title": "The Prophecy"
+              }
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 240000,
+              "title": "Cassandra",
+              "recording": {
+                "title": "Cassandra",
+                "id": "9a1b6a1a-7e6c-4aa9-a0b2-1afa13f232a0",
+                "length": 240000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false
+              },
+              "position": 11,
+              "id": "84e795c8-3cc9-4ff9-8c8b-e3f4511787be",
+              "number": "11"
+            },
+            {
+              "length": 284000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "title": "Peter",
+              "recording": {
+                "id": "efe3d337-3729-4cb1-836d-936c2bdc2fcd",
+                "title": "Peter",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "length": 283958,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ]
+              },
+              "position": 12,
+              "id": "b3a0ca1b-0646-4e4b-9cbd-2628168b423c",
+              "number": "12"
+            },
+            {
+              "length": 238000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "title": "The Bolter",
+              "recording": {
+                "id": "c8583b0f-1d1d-463a-be5a-87afba8b3ead",
+                "title": "The Bolter",
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 238241
+              },
+              "position": 13,
+              "id": "c3ea9aec-67a1-4b4c-855a-fff325874623",
+              "number": "13"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  }
+                }
+              ],
+              "length": 241000,
+              "id": "77f6cb50-38d7-434d-8dd1-1a002e305fb0",
+              "number": "14",
+              "title": "Robin",
+              "recording": {
+                "id": "7ad3475d-8315-41e6-83df-330dabff9e09",
+                "title": "Robin",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "length": 240893,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    }
+                  }
+                ]
+              },
+              "position": 14
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 225000,
+              "number": "15",
+              "id": "b5b14bec-8c17-4931-9392-0362a45a2a3e",
+              "recording": {
+                "title": "The Manuscript",
+                "id": "d0b283c4-93fc-42f1-8505-7937f0b80844",
+                "length": 224800,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": ""
+              },
+              "position": 15,
+              "title": "The Manuscript"
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "joinphrase": "",
+                  "name": "Post Malone",
+                  "artist": {
+                    "name": "Post Malone",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "country": "US",
+                    "sort-name": "Post Malone",
+                    "disambiguation": "",
+                    "genres": [
+                      {
+                        "count": 1,
+                        "name": "contemporary r&b",
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": ""
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "count": 1,
+                        "name": "country"
+                      },
+                      {
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "disambiguation": "",
+                        "count": 5,
+                        "name": "hip hop"
+                      },
+                      {
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                        "disambiguation": "",
+                        "name": "pop rap",
+                        "count": 2
+                      },
+                      {
+                        "count": 2,
+                        "name": "trap",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": ""
+                      }
+                    ],
+                    "type": "Person"
+                  }
+                }
+              ],
+              "length": 229000,
+              "number": "16",
+              "id": "8e41726e-3cd8-4202-add3-0d6798adc9b7",
+              "recording": {
+                "genres": [],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-06-10",
+                "length": 229000,
+                "artist-credit": [
+                  {
+                    "joinphrase": " featuring ",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  },
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Post Malone",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "disambiguation": ""
+                    },
+                    "name": "Post Malone",
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "33a409d3-5d2e-45fe-a237-e910d67db767",
+                "title": "Fortnight (acoustic version)"
+              },
+              "position": 16,
+              "title": "Fortnight (acoustic version)"
+            },
+            {
+              "length": 258000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "number": "17",
+              "id": "808dded5-a267-48ff-bcde-24232bf478c9",
+              "position": 17,
+              "recording": {
+                "title": "Down Bad (acoustic version)",
+                "id": "a76d46a7-7ec5-4125-a930-57f65227fa97",
+                "length": 258000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "genres": [],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-06-01"
+              },
+              "title": "Down Bad (acoustic version)"
+            },
+            {
+              "number": "18",
+              "id": "849e32d1-d5a7-4880-8421-7409aa94a7c7",
+              "recording": {
+                "first-release-date": "2024-05-24",
+                "disambiguation": "",
+                "video": false,
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 336000,
+                "id": "3ce3c81a-7f65-4092-a06c-278fced50a6f",
+                "title": "But Daddy I Love Him (acoustic version)"
+              },
+              "position": 18,
+              "title": "But Daddy I Love Him (acoustic version)",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 336000
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 250000,
+              "title": "Guilty as Sin? (acoustic version)",
+              "recording": {
+                "id": "4c905b81-958e-46e2-bce8-4c50bca8e384",
+                "title": "Guilty as Sin? (acoustic version)",
+                "genres": [],
+                "first-release-date": "2024-06-01",
+                "video": false,
+                "disambiguation": "",
+                "length": 250000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ]
+              },
+              "position": 19,
+              "id": "a910eded-a62b-48a6-a645-cb7c9e35f219",
+              "number": "19"
+            }
+          ],
+          "track-offset": 0
+        }
+      ],
+      "id": "5ed8a358-40d3-4891-a03e-15a91a3b5049"
+    },
+    {
+      "id": "6958b1d3-ef8f-493b-b368-aa16802b8343",
+      "country": "GB",
+      "asin": null,
+      "date": "2024-11-29",
+      "packaging": "Jewel Case",
+      "disambiguation": "",
+      "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+      "quality": "normal",
+      "media": [
+        {
+          "discs": [],
+          "position": 1,
+          "format": "CD",
+          "track-count": 16,
+          "title": "",
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "track-offset": 0,
+          "tracks": [
+            {
+              "id": "9bfe4538-566f-4f4e-aee9-1475c7a56d52",
+              "number": "1",
+              "title": "Fortnight",
+              "recording": {
+                "title": "Fortnight",
+                "id": "a06d6b37-9cae-40a5-806d-1a3c4f8098c0",
+                "artist-credit": [
+                  {
+                    "joinphrase": " featuring ",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  },
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone",
+                      "type": "Person",
+                      "sort-name": "Post Malone",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Post Malone"
+                  }
+                ],
+                "length": 228965,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "cloud rap",
+                    "id": "2346fb3e-8546-4119-a929-601db8e0a733",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                    "count": 1,
+                    "name": "contemporary r&b"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "9eb1c5f6-fa0a-495b-beb6-aba292fd3bbe",
+                    "disambiguation": "",
+                    "name": "country rap",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                    "count": 1,
+                    "name": "pop rap"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "rap rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "b4b184b7-6224-478e-a273-f9da9ee30136"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 1,
+              "artist-credit": [
+                {
+                  "joinphrase": " feat. ",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                },
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "genres": [
+                      {
+                        "count": 1,
+                        "name": "contemporary r&b",
+                        "disambiguation": "",
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0"
+                      },
+                      {
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "disambiguation": "",
+                        "name": "country",
+                        "count": 1
+                      },
+                      {
+                        "count": 5,
+                        "name": "hip hop",
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "disambiguation": ""
+                      },
+                      {
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                        "disambiguation": "",
+                        "name": "pop rap",
+                        "count": 2
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "name": "trap",
+                        "count": 2
+                      }
+                    ],
+                    "type": "Person",
+                    "sort-name": "Post Malone",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Post Malone",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19"
+                  },
+                  "name": "Post Malone"
+                }
+              ],
+              "length": 229000
+            },
+            {
+              "id": "d984e19f-fcb5-4710-b3bb-fe1312b0bcf0",
+              "number": "2",
+              "title": "The Tortured Poets Department",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 293053,
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 3,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "count": 5,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "title": "The Tortured Poets Department",
+                "id": "74fb3457-7db6-486d-be0b-af896a3925d9"
+              },
+              "position": 2,
+              "length": 293000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "number": "3",
+              "id": "40422552-0291-4c5f-b278-563db1436c31",
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 4
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 203800,
+                "id": "b1c44139-75ff-43a2-8dc6-c332ee8e16a4",
+                "title": "My Boy Only Breaks His Favorite Toys"
+              },
+              "position": 3,
+              "title": "My Boy Only Breaks His Favorite Toys",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 204000
+            },
+            {
+              "id": "a9d835d4-1e47-4a29-a537-46e5238afec9",
+              "number": "4",
+              "title": "Down Bad",
+              "recording": {
+                "id": "3bdc0830-9f84-4e10-82e7-a6fd6d0d4ebc",
+                "title": "Down Bad",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 3,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 261226
+              },
+              "position": 4,
+              "length": 261000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 263000,
+              "id": "301c21d9-82ff-4cc2-93be-76ae96913945",
+              "number": "5",
+              "title": "So Long, London",
+              "position": 5,
+              "recording": {
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 262973,
+                "id": "01e1cfa1-ee04-4e35-bca7-03c017ad86e3",
+                "title": "So Long, London"
+              }
+            },
+            {
+              "position": 6,
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 3,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "length": 340426,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "4399ef75-afc5-4e22-94ff-2a2d126e4e8e",
+                "title": "But Daddy I Love Him"
+              },
+              "title": "But Daddy I Love Him",
+              "number": "6",
+              "id": "392fe57b-0a3f-4280-b492-b9e9a47d4159",
+              "length": 340000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "length": 211000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "position": 7,
+              "recording": {
+                "id": "200a1d4b-2f3a-462b-8f98-20f1fc778928",
+                "title": "Fresh Out the Slammer",
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 210786
+              },
+              "title": "Fresh Out the Slammer",
+              "number": "7",
+              "id": "70d5346a-084c-4611-9b81-0712c6dd7cbb"
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "artist": {
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "name": "Florence + the Machine",
+                    "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6",
+                    "country": "GB",
+                    "type": "Group",
+                    "genres": [
+                      {
+                        "id": "ceeaa283-5d7b-4202-8d1d-e25d116b2a18",
+                        "disambiguation": "",
+                        "count": 2,
+                        "name": "alternative rock"
+                      },
+                      {
+                        "id": "930ef127-3653-4677-9b95-ecc90c7c1a14",
+                        "disambiguation": "",
+                        "count": 3,
+                        "name": "art pop"
+                      },
+                      {
+                        "id": "f390be72-360b-41bb-a310-6a2e638779d2",
+                        "disambiguation": "",
+                        "name": "indie pop",
+                        "count": 5
+                      },
+                      {
+                        "name": "indie rock",
+                        "count": 7,
+                        "disambiguation": "",
+                        "id": "ccd19ebf-052c-4afe-8ad9-fbb0a73f94a7"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                        "count": 2,
+                        "name": "pop"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                        "count": 1,
+                        "name": "pop rock"
+                      }
+                    ],
+                    "disambiguation": "",
+                    "sort-name": "Florence and the Machine"
+                  },
+                  "name": "Florence + the Machine",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 215000,
+              "title": "Florida!!!",
+              "position": 8,
+              "recording": {
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "length": 215466,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "joinphrase": " feat. "
+                  },
+                  {
+                    "joinphrase": "",
+                    "name": "Florence + the Machine",
+                    "artist": {
+                      "type": "Group",
+                      "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6",
+                      "disambiguation": "",
+                      "sort-name": "Florence and the Machine",
+                      "country": "GB",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "name": "Florence + the Machine"
+                    }
+                  }
+                ],
+                "id": "8e857bc8-4214-42b5-878a-c00567a9a3d1",
+                "title": "Florida!!!"
+              },
+              "id": "2a97da77-9335-45f1-ad1d-58e58121a18f",
+              "number": "8"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 254000,
+              "number": "9",
+              "id": "47dd1371-a8dc-44e9-a43a-817cbd64a80f",
+              "recording": {
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 254360,
+                "id": "b9262b85-ff4a-44db-aa6d-8dc8357c086d",
+                "title": "Guilty as Sin?"
+              },
+              "position": 9,
+              "title": "Guilty as Sin?"
+            },
+            {
+              "length": 334000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "number": "10",
+              "id": "b7a6d390-9d1d-4542-8787-39c1cc82260a",
+              "recording": {
+                "id": "d9630f72-27df-4369-973d-537cf2eb2954",
+                "title": "Who’s Afraid of Little Old Me?",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 334085
+              },
+              "position": 10,
+              "title": "Who’s Afraid of Little Old Me?"
+            },
+            {
+              "position": 11,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "length": 156293,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "I Can Fix Him (No Really I Can)",
+                "id": "085dab8e-2569-4864-8db5-fe150fd2587e"
+              },
+              "title": "I Can Fix Him (No Really I Can)",
+              "number": "11",
+              "id": "0d4155a8-83c0-4f7b-934a-10d3635c4ed5",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 156000
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 277000,
+              "number": "12",
+              "id": "7eb8e772-629f-4d74-9e5f-3effdb400cdd",
+              "position": 12,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 277160,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ],
+                "title": "loml",
+                "id": "ca5ab5ea-e0e7-4b2f-9124-a616b9fa0495"
+              },
+              "title": "loml"
+            },
+            {
+              "number": "13",
+              "id": "fa524437-35ab-4ff5-960b-80549e276b63",
+              "recording": {
+                "id": "940a2ac0-be80-4b48-a6cc-d1ac04a7d448",
+                "title": "I Can Do It With a Broken Heart",
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "name": "dance-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "b739a895-85ed-4ad3-8717-4e9ef5387dd8"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 4
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "length": 218000
+              },
+              "position": 13,
+              "title": "I Can Do It With a Broken Heart",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  }
+                }
+              ],
+              "length": 218000
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 246000,
+              "position": 14,
+              "recording": {
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "piano rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "34cd43be-4711-4e77-a25c-c6d6a4bf3cb4"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 245546,
+                "id": "ff7194ba-c5d3-4ce4-b231-bd90f7e9d187",
+                "title": "The Smallest Man Who Ever Lived"
+              },
+              "title": "The Smallest Man Who Ever Lived",
+              "number": "14",
+              "id": "360eb303-4876-4519-932e-0921dc0e7a1c"
+            },
+            {
+              "length": 197000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": ""
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "number": "15",
+              "id": "7baa98e2-24f6-4a25-94c6-437d10864a8b",
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "length": 196893,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "69a95746-70cc-44b0-a72b-1e6ac59f16a1",
+                "title": "The Alchemy"
+              },
+              "position": 15,
+              "title": "The Alchemy"
+            },
+            {
+              "number": "16",
+              "id": "d209549d-aed7-4e8d-b28b-74bb791aba8a",
+              "recording": {
+                "id": "1856e61e-2dde-4b5b-b596-5cb69fe0e211",
+                "title": "Clara Bow",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "folk pop",
+                    "count": 1,
+                    "id": "abb2374f-30e5-4d3e-b417-2caf78ef1f6c",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 2
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "length": 216666,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    }
+                  }
+                ]
+              },
+              "position": 16,
+              "title": "Clara Bow",
+              "length": 217000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "tracks": [
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 239000,
+              "title": "The Black Dog",
+              "position": 1,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "length": 239000,
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "f0843e91-c025-4dd7-8aef-6fe3d35470d9",
+                    "disambiguation": "",
+                    "name": "chamber pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "title": "The Black Dog",
+                "id": "a47f30f9-53f4-4222-8b38-934f818b41d1"
+              },
+              "id": "0b9afd85-e4fa-471a-9e71-2bb735bf0f43",
+              "number": "1"
+            },
+            {
+              "length": 222000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                }
+              ],
+              "number": "2",
+              "id": "67d9884b-009c-4c6b-bb40-0a0984006cb3",
+              "recording": {
+                "title": "imgonnagetyouback",
+                "id": "0ac1a42e-298d-41d6-b08f-817f27c730a3",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 222072,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ]
+              },
+              "position": 2,
+              "title": "imgonnagetyouback"
+            },
+            {
+              "title": "The Albatross",
+              "recording": {
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 183893,
+                "id": "6403174f-77a7-4c9d-91ca-4cbfcd097b00",
+                "title": "The Albatross"
+              },
+              "position": 3,
+              "id": "927c198a-c272-4adb-8244-757f9b0db395",
+              "number": "3",
+              "length": 184000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "number": "4",
+              "id": "a69f8bc2-3378-41ee-b75d-a933a4a2dc8b",
+              "recording": {
+                "title": "Chloe or Sam or Sophia or Marcus",
+                "id": "5a15e447-8d79-4be7-899b-f10d5a60765f",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 213281,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 4,
+              "title": "Chloe or Sam or Sophia or Marcus",
+              "length": 213000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ]
+            },
+            {
+              "length": 239000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "title": "How Did It End?",
+              "recording": {
+                "id": "e61dd61f-718f-46c1-86a7-29959bb08a3d",
+                "title": "How Did It End?",
+                "genres": [
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "length": 238707,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ]
+              },
+              "position": 5,
+              "id": "86499469-6556-41b6-a6db-856727eaa0b9",
+              "number": "5"
+            },
+            {
+              "recording": {
+                "id": "86c2568a-bb6f-4f9a-b491-d2ab09757849",
+                "title": "So High School",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "length": 228800,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ]
+              },
+              "position": 6,
+              "title": "So High School",
+              "number": "6",
+              "id": "5f4e2ef3-3d34-4bdb-b928-cd36f2836f8c",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "length": 244000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "id": "d4a73669-9714-4cbb-b2e2-61691d698548",
+              "number": "7",
+              "title": "I Hate It Here",
+              "recording": {
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 243876,
+                "id": "75e3a05a-6a05-45d7-b360-7dc3053cf873",
+                "title": "I Hate It Here"
+              },
+              "position": 7
+            },
+            {
+              "title": "thanK you aIMee",
+              "position": 8,
+              "recording": {
+                "id": "97c08c98-c016-47ed-9a85-601c00366edf",
+                "title": "thanK you aIMee",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit",
+                "length": 264000,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "id": "34582903-4830-4224-a43f-c9996af9a90d",
+              "number": "8",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 264000
+            },
+            {
+              "number": "9",
+              "id": "34e6996b-6724-45c7-ba4f-f6013b35d168",
+              "recording": {
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 131907,
+                "id": "8ab53640-10f4-4d01-9f92-75c7daa5ee25",
+                "title": "I Look in People’s Windows"
+              },
+              "position": 9,
+              "title": "I Look in People’s Windows",
+              "length": 132000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "length": 250000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "a3508eba-3e1c-4baf-ba16-a49616ec8c67",
+              "number": "10",
+              "title": "The Prophecy",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 249807,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "title": "The Prophecy",
+                "id": "e6f177d7-d979-4260-9ed2-66638c02ec3b"
+              },
+              "position": 10
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 240000,
+              "recording": {
+                "title": "Cassandra",
+                "id": "9a1b6a1a-7e6c-4aa9-a0b2-1afa13f232a0",
+                "length": 240000,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit"
+              },
+              "position": 11,
+              "title": "Cassandra",
+              "number": "11",
+              "id": "bfad31db-8231-46b1-9c37-c42d3e796b7c"
+            },
+            {
+              "length": 284000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "number": "12",
+              "id": "34eb65ff-907a-4ca0-8076-4bb38ce27fa6",
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 283958,
+                "id": "efe3d337-3729-4cb1-836d-936c2bdc2fcd",
+                "title": "Peter"
+              },
+              "position": 12,
+              "title": "Peter"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 238000,
+              "recording": {
+                "id": "c8583b0f-1d1d-463a-be5a-87afba8b3ead",
+                "title": "The Bolter",
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 238241
+              },
+              "position": 13,
+              "title": "The Bolter",
+              "number": "13",
+              "id": "cac33778-801d-49dd-b335-4ead82b5b1ad"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 241000,
+              "number": "14",
+              "id": "4935a34b-a3f1-4fb3-a467-39cbb8072780",
+              "position": 14,
+              "recording": {
+                "title": "Robin",
+                "id": "7ad3475d-8315-41e6-83df-330dabff9e09",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 240893,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ]
+              },
+              "title": "Robin"
+            },
+            {
+              "number": "15",
+              "id": "5ef75876-7170-4df4-964a-c7566e1e036d",
+              "position": 15,
+              "recording": {
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 224800,
+                "id": "d0b283c4-93fc-42f1-8505-7937f0b80844",
+                "title": "The Manuscript"
+              },
+              "title": "The Manuscript",
+              "length": 225000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "joinphrase": " feat. ",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                },
+                {
+                  "joinphrase": "",
+                  "name": "Post Malone",
+                  "artist": {
+                    "type": "Person",
+                    "genres": [
+                      {
+                        "disambiguation": "",
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "count": 1,
+                        "name": "contemporary r&b"
+                      },
+                      {
+                        "count": 1,
+                        "name": "country",
+                        "disambiguation": "",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "count": 5,
+                        "name": "hip hop"
+                      },
+                      {
+                        "count": 2,
+                        "name": "pop rap",
+                        "disambiguation": "",
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237"
+                      },
+                      {
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": "",
+                        "name": "trap",
+                        "count": 2
+                      }
+                    ],
+                    "sort-name": "Post Malone",
+                    "disambiguation": "",
+                    "country": "US",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Post Malone"
+                  }
+                }
+              ],
+              "title": "Fortnight (acoustic version)",
+              "recording": {
+                "id": "33a409d3-5d2e-45fe-a237-e910d67db767",
+                "title": "Fortnight (acoustic version)",
+                "video": false,
+                "first-release-date": "2024-06-10",
+                "disambiguation": "",
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "joinphrase": " featuring ",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  },
+                  {
+                    "joinphrase": "",
+                    "name": "Post Malone",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone",
+                      "type": "Person",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "sort-name": "Post Malone",
+                      "disambiguation": "",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "length": 229000
+              },
+              "position": 16,
+              "id": "cb4df5ba-4a15-4028-bab3-15c08028c8ab",
+              "number": "16"
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 258000,
+              "id": "10e2259f-3f3b-4492-ad98-b5e5f68bbc5a",
+              "number": "17",
+              "title": "Down Bad (acoustic version)",
+              "recording": {
+                "id": "a76d46a7-7ec5-4125-a930-57f65227fa97",
+                "title": "Down Bad (acoustic version)",
+                "genres": [],
+                "video": false,
+                "first-release-date": "2024-06-01",
+                "disambiguation": "",
+                "length": 258000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ]
+              },
+              "position": 17
+            },
+            {
+              "length": 336000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "1c94195d-6a93-44ae-87cd-1993c8902ecf",
+              "number": "18",
+              "title": "But Daddy I Love Him (acoustic version)",
+              "recording": {
+                "genres": [],
+                "disambiguation": "",
+                "first-release-date": "2024-05-24",
+                "video": false,
+                "length": 336000,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "3ce3c81a-7f65-4092-a06c-278fced50a6f",
+                "title": "But Daddy I Love Him (acoustic version)"
+              },
+              "position": 18
+            },
+            {
+              "length": 250000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "number": "19",
+              "id": "7de947de-f326-4bc4-b837-6a35b582eb66",
+              "position": 19,
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-06-01",
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 250000,
+                "id": "4c905b81-958e-46e2-bce8-4c50bca8e384",
+                "title": "Guilty as Sin? (acoustic version)"
+              },
+              "title": "Guilty as Sin? (acoustic version)"
+            }
+          ],
+          "track-offset": 0,
+          "title": "",
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "position": 2,
+          "discs": [],
+          "track-count": 19,
+          "format": "CD"
+        }
+      ],
+      "release-events": [
+        {
+          "date": "2024-11-29",
+          "area": {
+            "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+            "disambiguation": "",
+            "sort-name": "United Kingdom",
+            "type": null,
+            "iso-3166-1-codes": [
+              "GB"
+            ],
+            "name": "United Kingdom",
+            "type-id": null
+          }
+        },
+        {
+          "date": "2024-12-04",
+          "area": {
+            "type-id": null,
+            "name": "Europe",
+            "type": null,
+            "sort-name": "Europe",
+            "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+            "disambiguation": "",
+            "iso-3166-1-codes": [
+              "XE"
+            ]
+          }
+        }
+      ],
+      "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+      "title": "THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY",
+      "cover-art-archive": {
+        "back": true,
+        "artwork": true,
+        "front": true,
+        "darkened": false,
+        "count": 5
+      },
+      "genres": [],
+      "text-representation": {
+        "script": "Latn",
+        "language": "eng"
+      },
+      "artist-credit": [
+        {
+          "joinphrase": "",
+          "name": "Taylor Swift",
+          "artist": {
+            "sort-name": "Swift, Taylor",
+            "disambiguation": "",
+            "genres": [
+              {
+                "disambiguation": "",
+                "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                "count": 1,
+                "name": "alternative pop"
+              },
+              {
+                "count": 5,
+                "name": "contemporary country",
+                "id": "31c0b6ff-a356-4c73-91d7-203c80e6646b",
+                "disambiguation": ""
+              },
+              {
+                "count": 21,
+                "name": "country",
+                "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                "disambiguation": ""
+              },
+              {
+                "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                "disambiguation": "",
+                "count": 20,
+                "name": "country pop"
+              },
+              {
+                "disambiguation": "",
+                "id": "3f3388b4-e36a-4bf8-a0be-66b10d92aaa4",
+                "name": "electropop",
+                "count": 1
+              },
+              {
+                "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                "disambiguation": "",
+                "count": 2,
+                "name": "indie folk"
+              },
+              {
+                "disambiguation": "",
+                "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                "count": 35,
+                "name": "pop"
+              },
+              {
+                "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                "disambiguation": "",
+                "name": "pop rock",
+                "count": 6
+              },
+              {
+                "count": 5,
+                "name": "singer-songwriter",
+                "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                "disambiguation": ""
+              },
+              {
+                "count": 4,
+                "name": "synth-pop",
+                "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                "disambiguation": ""
+              }
+            ],
+            "type": "Person",
+            "country": "US",
+            "id": "20244d07-534f-4eff-b4d4-930878889970",
+            "name": "Taylor Swift",
+            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+          }
+        }
+      ],
+      "barcode": "602475028819",
+      "status": "Official"
+    },
+    {
+      "barcode": "602475028819",
+      "status": "Official",
+      "text-representation": {
+        "language": "eng",
+        "script": "Latn"
+      },
+      "artist-credit": [
+        {
+          "name": "Taylor Swift",
+          "artist": {
+            "sort-name": "Swift, Taylor",
+            "disambiguation": "",
+            "type": "Person",
+            "genres": [
+              {
+                "name": "alternative pop",
+                "count": 1,
+                "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                "disambiguation": ""
+              },
+              {
+                "count": 5,
+                "name": "contemporary country",
+                "disambiguation": "",
+                "id": "31c0b6ff-a356-4c73-91d7-203c80e6646b"
+              },
+              {
+                "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                "disambiguation": "",
+                "count": 21,
+                "name": "country"
+              },
+              {
+                "disambiguation": "",
+                "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                "name": "country pop",
+                "count": 20
+              },
+              {
+                "name": "electropop",
+                "count": 1,
+                "disambiguation": "",
+                "id": "3f3388b4-e36a-4bf8-a0be-66b10d92aaa4"
+              },
+              {
+                "count": 2,
+                "name": "indie folk",
+                "disambiguation": "",
+                "id": "36917620-240a-4fed-abcb-7be611ac3834"
+              },
+              {
+                "count": 35,
+                "name": "pop",
+                "disambiguation": "",
+                "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+              },
+              {
+                "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                "disambiguation": "",
+                "name": "pop rock",
+                "count": 6
+              },
+              {
+                "name": "singer-songwriter",
+                "count": 5,
+                "disambiguation": "",
+                "id": "455f264b-db00-4716-991d-fbd32dc24523"
+              },
+              {
+                "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                "disambiguation": "",
+                "count": 4,
+                "name": "synth-pop"
+              }
+            ],
+            "country": "US",
+            "name": "Taylor Swift",
+            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+            "id": "20244d07-534f-4eff-b4d4-930878889970"
+          },
+          "joinphrase": ""
+        }
+      ],
+      "cover-art-archive": {
+        "back": true,
+        "artwork": true,
+        "front": true,
+        "count": 21,
+        "darkened": false
+      },
+      "genres": [],
+      "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+      "title": "THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY",
+      "release-events": [
+        {
+          "date": "2024-11-29",
+          "area": {
+            "type-id": null,
+            "name": "Canada",
+            "iso-3166-1-codes": [
+              "CA"
+            ],
+            "type": null,
+            "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+            "disambiguation": "",
+            "sort-name": "Canada"
+          }
+        }
+      ],
+      "quality": "normal",
+      "media": [
+        {
+          "format": "CD",
+          "track-count": 16,
+          "position": 1,
+          "discs": [],
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "title": "",
+          "track-offset": 0,
+          "tracks": [
+            {
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "cloud rap",
+                    "id": "2346fb3e-8546-4119-a929-601db8e0a733",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "contemporary r&b",
+                    "count": 1,
+                    "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "id": "9eb1c5f6-fa0a-495b-beb6-aba292fd3bbe",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country rap"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rap"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "b4b184b7-6224-478e-a273-f9da9ee30136",
+                    "count": 1,
+                    "name": "rap rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ],
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "length": 228965,
+                "artist-credit": [
+                  {
+                    "joinphrase": " featuring ",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    }
+                  },
+                  {
+                    "joinphrase": "",
+                    "name": "Post Malone",
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Post Malone",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone"
+                    }
+                  }
+                ],
+                "id": "a06d6b37-9cae-40a5-806d-1a3c4f8098c0",
+                "title": "Fortnight"
+              },
+              "position": 1,
+              "title": "Fortnight",
+              "number": "1",
+              "id": "0dc698a0-2bc8-4d32-adc1-07cfbe0e7dae",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": " feat. "
+                },
+                {
+                  "name": "Post Malone",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Post Malone",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "country": "US",
+                    "genres": [
+                      {
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": "",
+                        "count": 1,
+                        "name": "contemporary r&b"
+                      },
+                      {
+                        "name": "country",
+                        "count": 1,
+                        "disambiguation": "",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe"
+                      },
+                      {
+                        "name": "hip hop",
+                        "count": 5,
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "disambiguation": ""
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                        "count": 2,
+                        "name": "pop rap"
+                      },
+                      {
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": "",
+                        "name": "trap",
+                        "count": 2
+                      }
+                    ],
+                    "type": "Person",
+                    "sort-name": "Post Malone",
+                    "disambiguation": ""
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  }
+                }
+              ],
+              "length": 293000,
+              "recording": {
+                "title": "The Tortured Poets Department",
+                "id": "74fb3457-7db6-486d-be0b-af896a3925d9",
+                "length": 293053,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": ""
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 3,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 5,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit"
+              },
+              "position": 2,
+              "title": "The Tortured Poets Department",
+              "number": "2",
+              "id": "9acdbe32-1ca9-4376-ab79-8589d6c0f991"
+            },
+            {
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 204000,
+              "number": "3",
+              "id": "0967b517-c49c-402f-a45e-9811d204cd48",
+              "recording": {
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 4,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 203800,
+                "id": "b1c44139-75ff-43a2-8dc6-c332ee8e16a4",
+                "title": "My Boy Only Breaks His Favorite Toys"
+              },
+              "position": 3,
+              "title": "My Boy Only Breaks His Favorite Toys"
+            },
+            {
+              "number": "4",
+              "id": "5ea58bc7-13b7-43ac-b47c-9b5a29c1fea4",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 261226,
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "name": "pop",
+                    "count": 2,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "Down Bad",
+                "id": "3bdc0830-9f84-4e10-82e7-a6fd6d0d4ebc"
+              },
+              "position": 4,
+              "title": "Down Bad",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 261000
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 263000,
+              "title": "So Long, London",
+              "recording": {
+                "title": "So Long, London",
+                "id": "01e1cfa1-ee04-4e35-bca7-03c017ad86e3",
+                "length": 262973,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false
+              },
+              "position": 5,
+              "id": "6d52fe96-9c03-494d-83d2-d69533240cb5",
+              "number": "5"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 340000,
+              "id": "59283dd8-7efe-46aa-8d49-6e9bf97fa6bf",
+              "number": "6",
+              "title": "But Daddy I Love Him",
+              "recording": {
+                "title": "But Daddy I Love Him",
+                "id": "4399ef75-afc5-4e22-94ff-2a2d126e4e8e",
+                "length": 340426,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 3,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19"
+              },
+              "position": 6
+            },
+            {
+              "id": "4e86adf5-e311-4066-9df4-66cc21cfa6e8",
+              "number": "7",
+              "title": "Fresh Out the Slammer",
+              "recording": {
+                "title": "Fresh Out the Slammer",
+                "id": "200a1d4b-2f3a-462b-8f98-20f1fc778928",
+                "length": 210786,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false
+              },
+              "position": 7,
+              "length": 211000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "recording": {
+                "title": "Florida!!!",
+                "id": "8e857bc8-4214-42b5-878a-c00567a9a3d1",
+                "length": 215466,
+                "artist-credit": [
+                  {
+                    "joinphrase": " feat. ",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  },
+                  {
+                    "artist": {
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "name": "Florence + the Machine",
+                      "type": "Group",
+                      "sort-name": "Florence and the Machine",
+                      "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6",
+                      "disambiguation": "",
+                      "country": "GB"
+                    },
+                    "name": "Florence + the Machine",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 3
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit"
+              },
+              "position": 8,
+              "title": "Florida!!!",
+              "number": "8",
+              "id": "0bd56d50-e75e-4984-981c-99b55fc10abb",
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": " feat. "
+                },
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "GB",
+                    "genres": [
+                      {
+                        "count": 2,
+                        "name": "alternative rock",
+                        "id": "ceeaa283-5d7b-4202-8d1d-e25d116b2a18",
+                        "disambiguation": ""
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "930ef127-3653-4677-9b95-ecc90c7c1a14",
+                        "count": 3,
+                        "name": "art pop"
+                      },
+                      {
+                        "name": "indie pop",
+                        "count": 5,
+                        "id": "f390be72-360b-41bb-a310-6a2e638779d2",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 7,
+                        "name": "indie rock",
+                        "id": "ccd19ebf-052c-4afe-8ad9-fbb0a73f94a7",
+                        "disambiguation": ""
+                      },
+                      {
+                        "name": "pop",
+                        "count": 2,
+                        "disambiguation": "",
+                        "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                      },
+                      {
+                        "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                        "disambiguation": "",
+                        "name": "pop rock",
+                        "count": 1
+                      }
+                    ],
+                    "type": "Group",
+                    "disambiguation": "",
+                    "sort-name": "Florence and the Machine",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "name": "Florence + the Machine",
+                    "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6"
+                  },
+                  "name": "Florence + the Machine"
+                }
+              ],
+              "length": 215000
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                }
+              ],
+              "length": 254000,
+              "id": "0e39148d-9d47-4f0d-88b8-e9e9ed79b52d",
+              "number": "9",
+              "title": "Guilty as Sin?",
+              "recording": {
+                "id": "b9262b85-ff4a-44db-aa6d-8dc8357c086d",
+                "title": "Guilty as Sin?",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 3,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 254360
+              },
+              "position": 9
+            },
+            {
+              "length": 334000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "position": 10,
+              "recording": {
+                "length": 334085,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "title": "Who’s Afraid of Little Old Me?",
+                "id": "d9630f72-27df-4369-973d-537cf2eb2954"
+              },
+              "title": "Who’s Afraid of Little Old Me?",
+              "number": "10",
+              "id": "4166c348-c6b4-4e3e-b20e-895253c796a2"
+            },
+            {
+              "number": "11",
+              "id": "79b30d47-dc88-45f1-a5d8-95bb77b64192",
+              "recording": {
+                "title": "I Can Fix Him (No Really I Can)",
+                "id": "085dab8e-2569-4864-8db5-fe150fd2587e",
+                "length": 156293,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": ""
+              },
+              "position": 11,
+              "title": "I Can Fix Him (No Really I Can)",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 156000
+            },
+            {
+              "recording": {
+                "length": 277160,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "title": "loml",
+                "id": "ca5ab5ea-e0e7-4b2f-9124-a616b9fa0495"
+              },
+              "position": 12,
+              "title": "loml",
+              "number": "12",
+              "id": "c81b39ff-f003-4fff-96c7-a5da41fb9d55",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 277000
+            },
+            {
+              "length": 218000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "number": "13",
+              "id": "4a63748e-0c67-46f0-a50c-c6bb75acecd6",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "length": 218000,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "b739a895-85ed-4ad3-8717-4e9ef5387dd8",
+                    "count": 1,
+                    "name": "dance-pop"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 4,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "I Can Do It With a Broken Heart",
+                "id": "940a2ac0-be80-4b48-a6cc-d1ac04a7d448"
+              },
+              "position": 13,
+              "title": "I Can Do It With a Broken Heart"
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 246000,
+              "id": "b0c563b0-75ff-427c-b368-149a54314edd",
+              "number": "14",
+              "title": "The Smallest Man Who Ever Lived",
+              "recording": {
+                "title": "The Smallest Man Who Ever Lived",
+                "id": "ff7194ba-c5d3-4ce4-b231-bd90f7e9d187",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 245546,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "34cd43be-4711-4e77-a25c-c6d6a4bf3cb4",
+                    "disambiguation": "",
+                    "name": "piano rock",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ]
+              },
+              "position": 14
+            },
+            {
+              "length": 197000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "7e0416ff-6b03-4838-84ad-3d06dd28014c",
+              "number": "15",
+              "title": "The Alchemy",
+              "recording": {
+                "title": "The Alchemy",
+                "id": "69a95746-70cc-44b0-a72b-1e6ac59f16a1",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 196893,
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 2
+                  }
+                ]
+              },
+              "position": 15
+            },
+            {
+              "number": "16",
+              "id": "0c3710bc-addd-433e-bdfc-40ea02bae4ee",
+              "position": 16,
+              "recording": {
+                "title": "Clara Bow",
+                "id": "1856e61e-2dde-4b5b-b596-5cb69fe0e211",
+                "length": 216666,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "folk pop",
+                    "count": 1,
+                    "id": "abb2374f-30e5-4d3e-b417-2caf78ef1f6c",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19"
+              },
+              "title": "Clara Bow",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 217000
+            }
+          ]
+        },
+        {
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "title": "",
+          "track-count": 19,
+          "format": "CD",
+          "position": 2,
+          "discs": [],
+          "tracks": [
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 239000,
+              "recording": {
+                "title": "The Black Dog",
+                "id": "a47f30f9-53f4-4222-8b38-934f818b41d1",
+                "length": 239000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "chamber pop",
+                    "count": 1,
+                    "id": "f0843e91-c025-4dd7-8aef-6fe3d35470d9",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit"
+              },
+              "position": 1,
+              "title": "The Black Dog",
+              "number": "1",
+              "id": "042fe2bf-45c6-4ea9-b3d2-5bf8b5346df5"
+            },
+            {
+              "recording": {
+                "id": "0ac1a42e-298d-41d6-b08f-817f27c730a3",
+                "title": "imgonnagetyouback",
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 222072
+              },
+              "position": 2,
+              "title": "imgonnagetyouback",
+              "number": "1",
+              "id": "67fc0521-9532-4816-8619-0e54c22fc76a",
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 222000
+            },
+            {
+              "number": "2",
+              "id": "241de50e-b664-4fed-b504-ff08cb6c0cf8",
+              "recording": {
+                "title": "The Albatross",
+                "id": "6403174f-77a7-4c9d-91ca-4cbfcd097b00",
+                "length": 183893,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19"
+              },
+              "position": 3,
+              "title": "The Albatross",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 184000
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                }
+              ],
+              "length": 213000,
+              "title": "Chloe or Sam or Sophia or Marcus",
+              "recording": {
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 213281,
+                "id": "5a15e447-8d79-4be7-899b-f10d5a60765f",
+                "title": "Chloe or Sam or Sophia or Marcus"
+              },
+              "position": 4,
+              "id": "125037c0-4525-486a-8bb0-5aae66052e1c",
+              "number": "3"
+            },
+            {
+              "number": "4",
+              "id": "0f97f5f5-5958-4ef7-9fd9-b659f8a92e9e",
+              "recording": {
+                "title": "How Did It End?",
+                "id": "e61dd61f-718f-46c1-86a7-29959bb08a3d",
+                "length": 238707,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19"
+              },
+              "position": 5,
+              "title": "How Did It End?",
+              "length": 239000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  }
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  }
+                }
+              ],
+              "length": 229000,
+              "id": "c650b9ff-3b45-4339-84e4-d21d02dee22e",
+              "number": "5",
+              "title": "So High School",
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "length": 228800,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "id": "86c2568a-bb6f-4f9a-b491-d2ab09757849",
+                "title": "So High School"
+              },
+              "position": 6
+            },
+            {
+              "length": 244000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "number": "6",
+              "id": "c8a32cf0-1dbc-4715-a675-4417de930624",
+              "recording": {
+                "id": "75e3a05a-6a05-45d7-b360-7dc3053cf873",
+                "title": "I Hate It Here",
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 243876
+              },
+              "position": 7,
+              "title": "I Hate It Here"
+            },
+            {
+              "title": "thanK you aIMee",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 264000,
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "title": "thanK you aIMee",
+                "id": "97c08c98-c016-47ed-9a85-601c00366edf"
+              },
+              "position": 8,
+              "id": "e4d95826-ba78-4a67-966f-d62670548bc2",
+              "number": "7",
+              "length": 264000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 132000,
+              "number": "8",
+              "id": "d22c67db-5cbf-41e8-808a-7a1e0c036bd3",
+              "recording": {
+                "title": "I Look in People’s Windows",
+                "id": "8ab53640-10f4-4d01-9f92-75c7daa5ee25",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 131907,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ]
+              },
+              "position": 9,
+              "title": "I Look in People’s Windows"
+            },
+            {
+              "length": 250000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "id": "75c85ef7-3fb4-40c8-b433-4d58806d27bc",
+              "number": "9",
+              "title": "The Prophecy",
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 249807,
+                "id": "e6f177d7-d979-4260-9ed2-66638c02ec3b",
+                "title": "The Prophecy"
+              },
+              "position": 10
+            },
+            {
+              "length": 240000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "title": "Cassandra",
+              "position": 11,
+              "recording": {
+                "id": "9a1b6a1a-7e6c-4aa9-a0b2-1afa13f232a0",
+                "title": "Cassandra",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit",
+                "length": 240000,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "id": "b03b357f-fc1e-4ce1-8526-bf4d04ecdac4",
+              "number": "10"
+            },
+            {
+              "number": "11",
+              "id": "39b58b5e-882b-4aca-944d-6a143b81e61a",
+              "recording": {
+                "length": 283958,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "video": false,
+                "title": "Peter",
+                "id": "efe3d337-3729-4cb1-836d-936c2bdc2fcd"
+              },
+              "position": 12,
+              "title": "Peter",
+              "length": 284000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "title": "The Bolter",
+              "position": 13,
+              "recording": {
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 238241,
+                "id": "c8583b0f-1d1d-463a-be5a-87afba8b3ead",
+                "title": "The Bolter"
+              },
+              "id": "c6364584-1a75-4235-b456-6f480631059c",
+              "number": "12",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 238000
+            },
+            {
+              "number": "13",
+              "id": "f3a855fa-bb48-4e01-97c3-d411a9c43bae",
+              "recording": {
+                "id": "7ad3475d-8315-41e6-83df-330dabff9e09",
+                "title": "Robin",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "length": 240893,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "position": 14,
+              "title": "Robin",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 241000
+            },
+            {
+              "length": 225000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "title": "The Manuscript",
+              "recording": {
+                "id": "d0b283c4-93fc-42f1-8505-7937f0b80844",
+                "title": "The Manuscript",
+                "genres": [
+                  {
+                    "name": "pop",
+                    "count": 2,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "length": 224800,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "position": 15,
+              "id": "4c67be95-81f5-4f29-a3bc-42eda8d1a97b",
+              "number": "14"
+            },
+            {
+              "title": "Fortnight (acoustic version)",
+              "recording": {
+                "title": "Fortnight (acoustic version)",
+                "id": "33a409d3-5d2e-45fe-a237-e910d67db767",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": " featuring "
+                  },
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Post Malone",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "disambiguation": "",
+                      "sort-name": "Post Malone"
+                    },
+                    "name": "Post Malone"
+                  }
+                ],
+                "length": 229000,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-06-10",
+                "genres": []
+              },
+              "position": 16,
+              "id": "4aa9302e-28f8-462b-8ebf-176b7e7fa2f3",
+              "number": "15",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "genres": [
+                      {
+                        "name": "contemporary r&b",
+                        "count": 1,
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": ""
+                      },
+                      {
+                        "count": 1,
+                        "name": "country",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "disambiguation": ""
+                      },
+                      {
+                        "name": "hip hop",
+                        "count": 5,
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "disambiguation": ""
+                      },
+                      {
+                        "name": "pop rap",
+                        "count": 2,
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                        "disambiguation": ""
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "count": 2,
+                        "name": "trap"
+                      }
+                    ],
+                    "sort-name": "Post Malone",
+                    "disambiguation": "",
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Post Malone"
+                  },
+                  "name": "Post Malone"
+                }
+              ]
+            },
+            {
+              "recording": {
+                "length": 258000,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [],
+                "disambiguation": "",
+                "first-release-date": "2024-06-01",
+                "video": false,
+                "title": "Down Bad (acoustic version)",
+                "id": "a76d46a7-7ec5-4125-a930-57f65227fa97"
+              },
+              "position": 17,
+              "title": "Down Bad (acoustic version)",
+              "number": "16",
+              "id": "80f47d12-2540-4d85-81ce-062e5b3061c0",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 258000
+            },
+            {
+              "title": "But Daddy I Love Him (acoustic version)",
+              "position": 18,
+              "recording": {
+                "id": "3ce3c81a-7f65-4092-a06c-278fced50a6f",
+                "title": "But Daddy I Love Him (acoustic version)",
+                "genres": [],
+                "disambiguation": "",
+                "first-release-date": "2024-05-24",
+                "video": false,
+                "length": 336000,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "id": "0913633f-fbb3-460c-ad5a-5c4fa9efd48c",
+              "number": "17",
+              "length": 336000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "length": 250000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  }
+                }
+              ],
+              "title": "Guilty as Sin? (acoustic version)",
+              "position": 19,
+              "recording": {
+                "title": "Guilty as Sin? (acoustic version)",
+                "id": "4c905b81-958e-46e2-bce8-4c50bca8e384",
+                "length": 250000,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-06-01"
+              },
+              "id": "f24b3d83-3e1c-4db6-ba01-99860bb5e4d8",
+              "number": "18"
+            }
+          ],
+          "track-offset": 0
+        }
+      ],
+      "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+      "disambiguation": "",
+      "country": "CA",
+      "date": "2024-11-29",
+      "packaging": "Jewel Case",
+      "asin": null,
+      "id": "79c238eb-b34b-47bf-921a-efc8db8f741b"
+    },
+    {
+      "title": "THE TORTURED POETS DEPARTMENT: THE ANTHOLOGY",
+      "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+      "release-events": [
+        {
+          "area": {
+            "type": null,
+            "disambiguation": "",
+            "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+            "sort-name": "Europe",
+            "iso-3166-1-codes": [
+              "XE"
+            ],
+            "type-id": null,
+            "name": "Europe"
+          },
+          "date": "2024-11-29"
+        },
+        {
+          "date": "2024-11-29",
+          "area": {
+            "iso-3166-1-codes": [
+              "US"
+            ],
+            "type": null,
+            "disambiguation": "",
+            "id": "489ce91b-6658-3307-9877-795b68554c98",
+            "sort-name": "United States",
+            "type-id": null,
+            "name": "United States"
+          }
+        }
+      ],
+      "status": "Official",
+      "barcode": "602475017622",
+      "artist-credit": [
+        {
+          "artist": {
+            "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+            "name": "Taylor Swift",
+            "id": "20244d07-534f-4eff-b4d4-930878889970",
+            "genres": [
+              {
+                "name": "alternative pop",
+                "count": 1,
+                "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                "disambiguation": ""
+              },
+              {
+                "count": 5,
+                "name": "contemporary country",
+                "disambiguation": "",
+                "id": "31c0b6ff-a356-4c73-91d7-203c80e6646b"
+              },
+              {
+                "name": "country",
+                "count": 21,
+                "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                "disambiguation": ""
+              },
+              {
+                "count": 20,
+                "name": "country pop",
+                "disambiguation": "",
+                "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+              },
+              {
+                "disambiguation": "",
+                "id": "3f3388b4-e36a-4bf8-a0be-66b10d92aaa4",
+                "count": 1,
+                "name": "electropop"
+              },
+              {
+                "disambiguation": "",
+                "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                "count": 2,
+                "name": "indie folk"
+              },
+              {
+                "name": "pop",
+                "count": 35,
+                "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                "disambiguation": ""
+              },
+              {
+                "name": "pop rock",
+                "count": 6,
+                "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                "disambiguation": ""
+              },
+              {
+                "name": "singer-songwriter",
+                "count": 5,
+                "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                "disambiguation": ""
+              },
+              {
+                "name": "synth-pop",
+                "count": 4,
+                "disambiguation": "",
+                "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+              }
+            ],
+            "type": "Person",
+            "disambiguation": "",
+            "sort-name": "Swift, Taylor",
+            "country": "US"
+          },
+          "name": "Taylor Swift",
+          "joinphrase": ""
+        }
+      ],
+      "text-representation": {
+        "script": "Latn",
+        "language": "eng"
+      },
+      "genres": [],
+      "cover-art-archive": {
+        "back": false,
+        "front": true,
+        "darkened": false,
+        "count": 29,
+        "artwork": true
+      },
+      "id": "ec2ad803-67ce-4ed3-9d20-29c4222a5954",
+      "quality": "normal",
+      "media": [
+        {
+          "title": "",
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+          "discs": [
+            {
+              "sectors": 293832,
+              "offsets": [
+                150,
+                17322,
+                39301,
+                54586,
+                74178,
+                93901,
+                119433,
+                135242,
+                151402,
+                170479,
+                195536,
+                207258,
+                228045,
+                244395,
+                262811,
+                277578
+              ],
+              "offset-count": 16,
+              "id": "BIcN8nPdfUY81nNkCmr3VmiaNeM-"
+            }
+          ],
+          "position": 1,
+          "format": "CD",
+          "track-count": 16,
+          "track-offset": 0,
+          "tracks": [
+            {
+              "recording": {
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "joinphrase": " featuring "
+                  },
+                  {
+                    "artist": {
+                      "name": "Post Malone",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "disambiguation": "",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "sort-name": "Post Malone",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Post Malone",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 228965,
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "2346fb3e-8546-4119-a929-601db8e0a733",
+                    "disambiguation": "",
+                    "name": "cloud rap",
+                    "count": 1
+                  },
+                  {
+                    "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "contemporary r&b"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "count": 1,
+                    "name": "country rap",
+                    "disambiguation": "",
+                    "id": "9eb1c5f6-fa0a-495b-beb6-aba292fd3bbe"
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                    "disambiguation": "",
+                    "name": "pop rap",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "name": "rap rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "b4b184b7-6224-478e-a273-f9da9ee30136"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "title": "Fortnight",
+                "id": "a06d6b37-9cae-40a5-806d-1a3c4f8098c0"
+              },
+              "position": 1,
+              "title": "Fortnight",
+              "number": "1",
+              "id": "7014c9f7-6e1a-4ae2-bd76-36c567907ccc",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "joinphrase": " feat. ",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                },
+                {
+                  "name": "Post Malone",
+                  "artist": {
+                    "country": "US",
+                    "sort-name": "Post Malone",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "genres": [
+                      {
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": "",
+                        "count": 1,
+                        "name": "contemporary r&b"
+                      },
+                      {
+                        "count": 1,
+                        "name": "country",
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "disambiguation": ""
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "name": "hip hop",
+                        "count": 5
+                      },
+                      {
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237",
+                        "disambiguation": "",
+                        "count": 2,
+                        "name": "pop rap"
+                      },
+                      {
+                        "count": 2,
+                        "name": "trap",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": ""
+                      }
+                    ],
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "name": "Post Malone",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 293000,
+              "id": "b72dda63-e6cd-49c3-9603-5b542cc83b4f",
+              "number": "2",
+              "title": "The Tortured Poets Department",
+              "recording": {
+                "title": "The Tortured Poets Department",
+                "id": "74fb3457-7db6-486d-be0b-af896a3925d9",
+                "length": 293053,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 3
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 5,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19"
+              },
+              "position": 2
+            },
+            {
+              "recording": {
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 2,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 4
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 203800,
+                "id": "b1c44139-75ff-43a2-8dc6-c332ee8e16a4",
+                "title": "My Boy Only Breaks His Favorite Toys"
+              },
+              "position": 3,
+              "title": "My Boy Only Breaks His Favorite Toys",
+              "number": "3",
+              "id": "3a959bff-6d24-4a7b-b3f9-cd685b0141d4",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 204000
+            },
+            {
+              "length": 261000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "recording": {
+                "title": "Down Bad",
+                "id": "3bdc0830-9f84-4e10-82e7-a6fd6d0d4ebc",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "length": 261226,
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "name": "pop rock",
+                    "count": 2
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ]
+              },
+              "position": 4,
+              "title": "Down Bad",
+              "number": "4",
+              "id": "51092637-b97e-4826-a088-95e694bfc51a"
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 263000,
+              "id": "dc5c0982-ca66-4c07-abb3-6ca0058030df",
+              "number": "5",
+              "title": "So Long, London",
+              "position": 5,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    }
+                  }
+                ],
+                "length": 262973,
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 2,
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 3
+                  }
+                ],
+                "title": "So Long, London",
+                "id": "01e1cfa1-ee04-4e35-bca7-03c017ad86e3"
+              }
+            },
+            {
+              "length": 340000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "position": 6,
+              "recording": {
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "count": 3,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 340426,
+                "id": "4399ef75-afc5-4e22-94ff-2a2d126e4e8e",
+                "title": "But Daddy I Love Him"
+              },
+              "title": "But Daddy I Love Him",
+              "number": "6",
+              "id": "07d2af89-4f7e-443b-be19-19dc5e03a850"
+            },
+            {
+              "id": "e6926a8c-bfd9-4f8c-bba5-0f0b07bf117e",
+              "number": "7",
+              "title": "Fresh Out the Slammer",
+              "position": 7,
+              "recording": {
+                "id": "200a1d4b-2f3a-462b-8f98-20f1fc778928",
+                "title": "Fresh Out the Slammer",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "length": 210786,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 211000
+            },
+            {
+              "length": 215000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "joinphrase": " feat. "
+                },
+                {
+                  "artist": {
+                    "sort-name": "Florence and the Machine",
+                    "disambiguation": "",
+                    "genres": [
+                      {
+                        "id": "ceeaa283-5d7b-4202-8d1d-e25d116b2a18",
+                        "disambiguation": "",
+                        "name": "alternative rock",
+                        "count": 2
+                      },
+                      {
+                        "name": "art pop",
+                        "count": 3,
+                        "id": "930ef127-3653-4677-9b95-ecc90c7c1a14",
+                        "disambiguation": ""
+                      },
+                      {
+                        "id": "f390be72-360b-41bb-a310-6a2e638779d2",
+                        "disambiguation": "",
+                        "count": 5,
+                        "name": "indie pop"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "ccd19ebf-052c-4afe-8ad9-fbb0a73f94a7",
+                        "name": "indie rock",
+                        "count": 7
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                        "count": 2,
+                        "name": "pop"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                        "count": 1,
+                        "name": "pop rock"
+                      }
+                    ],
+                    "type": "Group",
+                    "country": "GB",
+                    "name": "Florence + the Machine",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6"
+                  },
+                  "name": "Florence + the Machine",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "2b16fd87-f3d6-488f-a091-e98cee2f7de5",
+              "number": "8",
+              "title": "Florida!!!",
+              "position": 8,
+              "recording": {
+                "title": "Florida!!!",
+                "id": "8e857bc8-4214-42b5-878a-c00567a9a3d1",
+                "artist-credit": [
+                  {
+                    "joinphrase": " feat. ",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  },
+                  {
+                    "artist": {
+                      "name": "Florence + the Machine",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "sort-name": "Florence and the Machine",
+                      "id": "5fee3020-513b-48c2-b1f7-4681b01db0c6",
+                      "disambiguation": "",
+                      "type": "Group",
+                      "country": "GB"
+                    },
+                    "name": "Florence + the Machine",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 215466,
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "explicit",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 3,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 3
+                  }
+                ]
+              }
+            },
+            {
+              "number": "9",
+              "id": "c510700c-ec14-4041-bfbd-a612f0347daa",
+              "recording": {
+                "length": 254360,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "indie folk"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 3,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 3
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "title": "Guilty as Sin?",
+                "id": "b9262b85-ff4a-44db-aa6d-8dc8357c086d"
+              },
+              "position": 9,
+              "title": "Guilty as Sin?",
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 254000
+            },
+            {
+              "number": "10",
+              "id": "44aac3e7-ef42-4dce-af46-a6cac67282f6",
+              "recording": {
+                "title": "Who’s Afraid of Little Old Me?",
+                "id": "d9630f72-27df-4369-973d-537cf2eb2954",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 334085,
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ]
+              },
+              "position": 10,
+              "title": "Who’s Afraid of Little Old Me?",
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 334000
+            },
+            {
+              "title": "I Can Fix Him (No Really I Can)",
+              "recording": {
+                "title": "I Can Fix Him (No Really I Can)",
+                "id": "085dab8e-2569-4864-8db5-fe150fd2587e",
+                "length": 156293,
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "disambiguation": "",
+                    "name": "country pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": "",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": ""
+              },
+              "position": 11,
+              "id": "688b1171-ff5f-4957-b0ae-81bd80172119",
+              "number": "11",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  }
+                }
+              ],
+              "length": 156000
+            },
+            {
+              "title": "loml",
+              "recording": {
+                "title": "loml",
+                "id": "ca5ab5ea-e0e7-4b2f-9124-a616b9fa0495",
+                "length": 277160,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19"
+              },
+              "position": 12,
+              "id": "4f4515e5-1efb-4d13-83e5-c4e90e4f99d1",
+              "number": "12",
+              "length": 277000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "id": "1b4e0c69-3df8-4d02-b6cb-eb7078162ad4",
+              "number": "13",
+              "title": "I Can Do It With a Broken Heart",
+              "recording": {
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 2,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1",
+                    "count": 1,
+                    "name": "country pop"
+                  },
+                  {
+                    "id": "b739a895-85ed-4ad3-8717-4e9ef5387dd8",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "dance-pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "name": "indie folk",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "count": 4,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 218000,
+                "id": "940a2ac0-be80-4b48-a6cc-d1ac04a7d448",
+                "title": "I Can Do It With a Broken Heart"
+              },
+              "position": 13,
+              "length": 218000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                }
+              ]
+            },
+            {
+              "number": "14",
+              "id": "f07b5bee-900f-4861-9326-0250c687a3e2",
+              "position": 14,
+              "recording": {
+                "id": "ff7194ba-c5d3-4ce4-b231-bd90f7e9d187",
+                "title": "The Smallest Man Who Ever Lived",
+                "first-release-date": "2024-04-19",
+                "disambiguation": "explicit",
+                "video": false,
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "name": "piano rock",
+                    "count": 1,
+                    "id": "34cd43be-4711-4e77-a25c-c6d6a4bf3cb4",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 245546
+              },
+              "title": "The Smallest Man Who Ever Lived",
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  }
+                }
+              ],
+              "length": 246000
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 197000,
+              "id": "515e9e7d-181a-4a7a-a12f-ff6f9d20017f",
+              "number": "15",
+              "title": "The Alchemy",
+              "recording": {
+                "title": "The Alchemy",
+                "id": "69a95746-70cc-44b0-a72b-1e6ac59f16a1",
+                "length": 196893,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "country pop",
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 1,
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 2,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 2,
+                    "name": "synth-pop"
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19"
+              },
+              "position": 15
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 217000,
+              "recording": {
+                "length": 216666,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": ""
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "name": "alternative pop",
+                    "count": 2
+                  },
+                  {
+                    "name": "country pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "2de61e9c-de1d-47c8-999d-5b44c0cfeca1"
+                  },
+                  {
+                    "name": "folk pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "abb2374f-30e5-4d3e-b417-2caf78ef1f6c"
+                  },
+                  {
+                    "name": "indie folk",
+                    "count": 2,
+                    "disambiguation": "",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834"
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "count": 2,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "title": "Clara Bow",
+                "id": "1856e61e-2dde-4b5b-b596-5cb69fe0e211"
+              },
+              "position": 16,
+              "title": "Clara Bow",
+              "number": "16",
+              "id": "99a87345-347a-45a9-8b52-1700ca867907"
+            }
+          ]
+        },
+        {
+          "track-offset": 0,
+          "tracks": [
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "length": 239000,
+              "title": "The Black Dog",
+              "recording": {
+                "id": "a47f30f9-53f4-4222-8b38-934f818b41d1",
+                "title": "The Black Dog",
+                "video": false,
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "name": "chamber pop",
+                    "count": 1,
+                    "id": "f0843e91-c025-4dd7-8aef-6fe3d35470d9",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor"
+                    }
+                  }
+                ],
+                "length": 239000
+              },
+              "position": 1,
+              "id": "83b0de16-8725-4c5b-bfb7-b379f4a95992",
+              "number": "1"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person"
+                  }
+                }
+              ],
+              "length": 222000,
+              "number": "2",
+              "id": "eb2329d2-0061-496f-8aac-6d9f0ca5c276",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 222072,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ],
+                "title": "imgonnagetyouback",
+                "id": "0ac1a42e-298d-41d6-b08f-817f27c730a3"
+              },
+              "position": 2,
+              "title": "imgonnagetyouback"
+            },
+            {
+              "length": 184000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "number": "3",
+              "id": "b5297a34-b48f-430d-a80f-bec8b915f246",
+              "recording": {
+                "id": "6403174f-77a7-4c9d-91ca-4cbfcd097b00",
+                "title": "The Albatross",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "name": "singer-songwriter",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 183893
+              },
+              "position": 3,
+              "title": "The Albatross"
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 213000,
+              "id": "c5db5d1c-1295-4403-a021-d59147a39f0e",
+              "number": "4",
+              "title": "Chloe or Sam or Sophia or Marcus",
+              "position": 4,
+              "recording": {
+                "id": "5a15e447-8d79-4be7-899b-f10d5a60765f",
+                "title": "Chloe or Sam or Sophia or Marcus",
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "length": 213281
+              }
+            },
+            {
+              "length": 239000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "id": "65916ccd-07eb-415d-ad2b-1e68472b0cb9",
+              "number": "5",
+              "title": "How Did It End?",
+              "recording": {
+                "id": "e61dd61f-718f-46c1-86a7-29959bb08a3d",
+                "title": "How Did It End?",
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "pop",
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "count": 1,
+                    "name": "synth-pop",
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 238707
+              },
+              "position": 5
+            },
+            {
+              "number": "6",
+              "id": "7af9f110-9774-47cb-a9d0-da735ea48ca1",
+              "recording": {
+                "title": "So High School",
+                "id": "86c2568a-bb6f-4f9a-b491-d2ab09757849",
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 228800,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "count": 2,
+                    "name": "pop"
+                  },
+                  {
+                    "count": 2,
+                    "name": "pop rock",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": ""
+                  }
+                ]
+              },
+              "position": 6,
+              "title": "So High School",
+              "length": 229000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 244000,
+              "id": "487c54fb-068b-4a5c-a368-1ea6d4a0c0c9",
+              "number": "7",
+              "title": "I Hate It Here",
+              "recording": {
+                "id": "75e3a05a-6a05-45d7-b360-7dc3053cf873",
+                "title": "I Hate It Here",
+                "genres": [
+                  {
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "length": 243876,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "position": 7
+            },
+            {
+              "length": 264000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "disambiguation": "",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift"
+                }
+              ],
+              "number": "8",
+              "id": "79d0acc0-50ae-48cd-8839-77e232acca17",
+              "recording": {
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "name": "alternative pop",
+                    "count": 1
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "explicit",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "length": 264000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "id": "97c08c98-c016-47ed-9a85-601c00366edf",
+                "title": "thanK you aIMee"
+              },
+              "position": 8,
+              "title": "thanK you aIMee"
+            },
+            {
+              "number": "9",
+              "id": "b5d6c440-d4f9-498d-b479-9a806168dc38",
+              "recording": {
+                "id": "8ab53640-10f4-4d01-9f92-75c7daa5ee25",
+                "title": "I Look in People’s Windows",
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 131907
+              },
+              "position": 9,
+              "title": "I Look in People’s Windows",
+              "length": 132000,
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "country": "US",
+                    "type": "Person",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": ""
+                  },
+                  "name": "Taylor Swift"
+                }
+              ]
+            },
+            {
+              "id": "9e673ebb-236f-4f6c-bf02-c69a60542757",
+              "number": "10",
+              "title": "The Prophecy",
+              "position": 10,
+              "recording": {
+                "title": "The Prophecy",
+                "id": "e6f177d7-d979-4260-9ed2-66638c02ec3b",
+                "length": 249807,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop rock",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "synth-pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac"
+                  }
+                ],
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false
+              },
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "country": "US"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 250000
+            },
+            {
+              "length": 240000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "sort-name": "Swift, Taylor",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "type": "Person",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "position": 11,
+              "recording": {
+                "genres": [
+                  {
+                    "name": "alternative pop",
+                    "count": 1,
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": ""
+                  },
+                  {
+                    "name": "pop",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791"
+                  },
+                  {
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "singer-songwriter"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "length": 240000,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "id": "9a1b6a1a-7e6c-4aa9-a0b2-1afa13f232a0",
+                "title": "Cassandra"
+              },
+              "title": "Cassandra",
+              "number": "11",
+              "id": "aee5aee1-3eb6-4b41-bcaf-edee560c6daa"
+            },
+            {
+              "number": "12",
+              "id": "7a1f835b-3ed7-42f1-81d8-fb3a3cf0e141",
+              "position": 12,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "country": "US",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    }
+                  }
+                ],
+                "length": 283958,
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "disambiguation": "",
+                "genres": [
+                  {
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "alternative pop"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop rock"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ],
+                "title": "Peter",
+                "id": "efe3d337-3729-4cb1-836d-936c2bdc2fcd"
+              },
+              "title": "Peter",
+              "length": 284000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US"
+                  },
+                  "joinphrase": ""
+                }
+              ]
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 238000,
+              "id": "268c918b-4e20-4611-997d-f024bc892771",
+              "number": "13",
+              "title": "The Bolter",
+              "recording": {
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "count": 1,
+                    "name": "indie folk",
+                    "id": "36917620-240a-4fed-abcb-7be611ac3834",
+                    "disambiguation": ""
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "pop"
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "disambiguation": "explicit",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "length": 238241,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "id": "c8583b0f-1d1d-463a-be5a-87afba8b3ead",
+                "title": "The Bolter"
+              },
+              "position": 13
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  }
+                }
+              ],
+              "length": 241000,
+              "id": "c0f2c1d7-63fd-47a4-ad15-1e067dd2c6a0",
+              "number": "14",
+              "title": "Robin",
+              "position": 14,
+              "recording": {
+                "title": "Robin",
+                "id": "7ad3475d-8315-41e6-83df-330dabff9e09",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "country": "US"
+                    },
+                    "name": "Taylor Swift"
+                  }
+                ],
+                "length": 240893,
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-04-19",
+                "genres": [
+                  {
+                    "count": 1,
+                    "name": "alternative pop",
+                    "disambiguation": "",
+                    "id": "d3ebe947-7c03-43f5-b333-09379881b0f6"
+                  },
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 1
+                  },
+                  {
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e",
+                    "name": "pop rock",
+                    "count": 1
+                  },
+                  {
+                    "count": 1,
+                    "name": "singer-songwriter",
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "name": "synth-pop",
+                    "count": 1
+                  }
+                ]
+              }
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 225000,
+              "position": 15,
+              "recording": {
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                    }
+                  }
+                ],
+                "length": 224800,
+                "disambiguation": "",
+                "first-release-date": "2024-04-19",
+                "video": false,
+                "genres": [
+                  {
+                    "id": "911c7bbb-172d-4df8-9478-dbff4296e791",
+                    "disambiguation": "",
+                    "name": "pop",
+                    "count": 2
+                  },
+                  {
+                    "count": 1,
+                    "name": "pop rock",
+                    "disambiguation": "",
+                    "id": "797e2e85-5ffd-495c-a757-8b4079052f0e"
+                  },
+                  {
+                    "name": "singer-songwriter",
+                    "count": 1,
+                    "disambiguation": "",
+                    "id": "455f264b-db00-4716-991d-fbd32dc24523"
+                  },
+                  {
+                    "id": "988e91a3-3341-416d-b7f8-7dbef6848dac",
+                    "disambiguation": "",
+                    "count": 1,
+                    "name": "synth-pop"
+                  }
+                ],
+                "title": "The Manuscript",
+                "id": "d0b283c4-93fc-42f1-8505-7937f0b80844"
+              },
+              "title": "The Manuscript",
+              "number": "15",
+              "id": "03d6f7c8-c47a-44fc-a4e1-2c06fa60dc9f"
+            },
+            {
+              "artist-credit": [
+                {
+                  "joinphrase": " feat. ",
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  }
+                },
+                {
+                  "joinphrase": "",
+                  "name": "Post Malone",
+                  "artist": {
+                    "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                    "name": "Post Malone",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "disambiguation": "",
+                    "sort-name": "Post Malone",
+                    "genres": [
+                      {
+                        "count": 1,
+                        "name": "contemporary r&b",
+                        "id": "4bb4043a-0ee5-4b84-93fa-6ba4567a6ba0",
+                        "disambiguation": ""
+                      },
+                      {
+                        "id": "5f665615-7fb3-49d8-b541-62a7b239edbe",
+                        "disambiguation": "",
+                        "count": 1,
+                        "name": "country"
+                      },
+                      {
+                        "disambiguation": "",
+                        "id": "52faa157-6bad-4d86-a0ab-d4dec7d2513c",
+                        "name": "hip hop",
+                        "count": 5
+                      },
+                      {
+                        "name": "pop rap",
+                        "count": 2,
+                        "disambiguation": "",
+                        "id": "da2fc3b4-b97d-491a-ac0f-8a731bee7237"
+                      },
+                      {
+                        "count": 2,
+                        "name": "trap",
+                        "id": "9a339aa8-a0e5-450c-95a7-b11517bb508f",
+                        "disambiguation": ""
+                      }
+                    ],
+                    "type": "Person",
+                    "country": "US"
+                  }
+                }
+              ],
+              "length": 229000,
+              "number": "16",
+              "id": "1aaa98b4-1102-47a7-a4b4-b16d9a768e3c",
+              "position": 16,
+              "recording": {
+                "disambiguation": "",
+                "first-release-date": "2024-06-10",
+                "video": false,
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "disambiguation": "",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "type": "Person"
+                    },
+                    "joinphrase": " featuring "
+                  },
+                  {
+                    "artist": {
+                      "name": "Post Malone",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "sort-name": "Post Malone",
+                      "id": "b1e26560-60e5-4236-bbdb-9aa5a8d5ee19",
+                      "disambiguation": "",
+                      "type": "Person",
+                      "country": "US"
+                    },
+                    "name": "Post Malone",
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 229000,
+                "id": "33a409d3-5d2e-45fe-a237-e910d67db767",
+                "title": "Fortnight (acoustic version)"
+              },
+              "title": "Fortnight (acoustic version)"
+            },
+            {
+              "length": 258000,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "US",
+                    "type": "Person",
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "name": "Taylor Swift"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "id": "dcad5d70-40a1-490c-b4cd-566d2e95432d",
+              "number": "17",
+              "title": "Down Bad (acoustic version)",
+              "recording": {
+                "id": "a76d46a7-7ec5-4125-a930-57f65227fa97",
+                "title": "Down Bad (acoustic version)",
+                "disambiguation": "",
+                "video": false,
+                "first-release-date": "2024-06-01",
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "name": "Taylor Swift",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "country": "US",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "sort-name": "Swift, Taylor",
+                      "disambiguation": "",
+                      "type": "Person"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 258000
+              },
+              "position": 17
+            },
+            {
+              "length": 336000,
+              "artist-credit": [
+                {
+                  "name": "Taylor Swift",
+                  "artist": {
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                    "country": "US",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "disambiguation": "",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "recording": {
+                "id": "3ce3c81a-7f65-4092-a06c-278fced50a6f",
+                "title": "But Daddy I Love Him (acoustic version)",
+                "disambiguation": "",
+                "first-release-date": "2024-05-24",
+                "video": false,
+                "genres": [],
+                "artist-credit": [
+                  {
+                    "name": "Taylor Swift",
+                    "artist": {
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift",
+                      "country": "US",
+                      "type": "Person",
+                      "sort-name": "Swift, Taylor",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": ""
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 336000
+              },
+              "position": 18,
+              "title": "But Daddy I Love Him (acoustic version)",
+              "number": "18",
+              "id": "64c557e2-9dac-4cb9-a14c-cad7e77089a5"
+            },
+            {
+              "artist-credit": [
+                {
+                  "artist": {
+                    "disambiguation": "",
+                    "id": "20244d07-534f-4eff-b4d4-930878889970",
+                    "sort-name": "Swift, Taylor",
+                    "type": "Person",
+                    "country": "US",
+                    "name": "Taylor Swift",
+                    "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                  },
+                  "name": "Taylor Swift",
+                  "joinphrase": ""
+                }
+              ],
+              "length": 250000,
+              "recording": {
+                "title": "Guilty as Sin? (acoustic version)",
+                "id": "4c905b81-958e-46e2-bce8-4c50bca8e384",
+                "length": 250000,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "country": "US",
+                      "type": "Person",
+                      "id": "20244d07-534f-4eff-b4d4-930878889970",
+                      "disambiguation": "",
+                      "sort-name": "Swift, Taylor",
+                      "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                      "name": "Taylor Swift"
+                    },
+                    "name": "Taylor Swift",
+                    "joinphrase": ""
+                  }
+                ],
+                "genres": [],
+                "video": false,
+                "disambiguation": "",
+                "first-release-date": "2024-06-01"
+              },
+              "position": 19,
+              "title": "Guilty as Sin? (acoustic version)",
+              "number": "19",
+              "id": "7e4b76bc-bd8b-4127-8670-339ccb3c2290"
+            }
+          ],
+          "discs": [
+            {
+              "offset-count": 19,
+              "sectors": 338952,
+              "offsets": [
+                150,
+                18064,
+                34719,
+                48510,
+                64506,
+                82409,
+                99569,
+                117860,
+                137646,
+                147539,
+                166275,
+                184290,
+                205587,
+                223455,
+                241522,
+                258378,
+                275550,
+                294931,
+                320173
+              ],
+              "id": "XoGwK8t1eeR.pBP8rWC1qTQniCU-"
+            }
+          ],
+          "position": 2,
+          "format": "CD",
+          "track-count": 19,
+          "title": "",
+          "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+        }
+      ],
+      "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+      "disambiguation": "",
+      "asin": null,
+      "date": "2024-11-29",
+      "packaging": "Jewel Case",
+      "country": "XE"
+    }
+  ]
+}

--- a/src/test/music_brainz_test.exs
+++ b/src/test/music_brainz_test.exs
@@ -1,6 +1,5 @@
 defmodule MusicBrainzTest do
   use ExUnit.Case, async: true
-  alias Cddb.Disc
 
   defp load_mock(name) do
     "test/fixtures/music_brainz/#{name}.json"
@@ -23,57 +22,12 @@ defmodule MusicBrainzTest do
 
   doctest MusicBrainz
 
-  test "release_to_disc/2 converts release info to Disc" do
-    release =
-      "test/fixtures/music_brainz/fuzzy_response.json"
-      |> File.read!()
-      |> Jason.decode!()
-      |> Map.get("releases")
-      |> Enum.at(0)
-
-    expectation = %Disc{
-      id: "940aac0d",
-      artist: "Marina & the Diamonds",
-      title: "The Family Jewels",
-      year: "2010",
-      genre: "misc",
-      tracks: [
-        {"Are You Satisfied?", nil},
-        {"Shampain", nil},
-        {"I Am Not a Robot", nil},
-        {"Girls", nil},
-        {"Mowgli's Road", nil},
-        {"Obsessions", nil},
-        {"Hollywood", nil},
-        {"The Outsider", nil},
-        {"Hermit the Frog", nil},
-        {"Oh No!", nil},
-        {"Rootless", nil},
-        {"Numb", nil},
-        {"Guilty", nil}
-      ]
-    }
-
-    assert MusicBrainz.release_to_disc("940aac0d", release) == expectation
-  end
-
-  test "release_to_disc/2 works when genre is present" do
-    release =
-      "test/fixtures/music_brainz/disc_with_genre.json"
-      |> File.read!()
-      |> Jason.decode!()
-      |> Map.get("releases")
-      |> Enum.at(0)
-
-    assert %Disc{genre: "blues"} = MusicBrainz.release_to_disc("860a9b0a", release)
-  end
-
   @tag capture_log: true
-  test "find_release/2 when there are multiple disc layouts for the album" do
+  test "find_releases/2 when there are multiple disc layouts for the album" do
     length = 4223
     toc = ~w[182 3250 30272 61607 93215 118357 141452 175105 211805 251415 282740]
 
-    {:ok, results} = MusicBrainz.find_release(length, toc)
+    {:ok, results} = MusicBrainz.find_releases(%{length_seconds: length, track_lbas: toc})
     assert length(results) == 1
   end
 end


### PR DESCRIPTION
## Multi-disc albums

I found this when trying to rip CD 2 of a two-disc album.

CDDB identifies individual discs on their own. If there's a two-disc album, those discs are completely separate with no relation to each other.

In MusicBrainz, the "release" is the whole album and it can contain multiple "media" elements to indicate multiple discs.

Since both CDDB and MSDC think in terms of discs, we have to find a matching release *and* the matching disc and then combine them to one "disc" in terms that CDDB and MSCD can use.

Way back when I had hardcoded fetching the first "media" element from an album match. I may not have realised that there's a fundamental difference between how CDDB and MusicBrainz organise media.

## Trailing newlines

There were two cases where trailing newlines were missing from responses. In the case of CDDB over HTTP, this caused Exact Audio Copy to fail to understand a "no match" response.